### PR TITLE
use NLL loss instead of cross entropy

### DIFF
--- a/R/torch_mlp-fit.R
+++ b/R/torch_mlp-fit.R
@@ -393,7 +393,9 @@ torch_mlp_reg_fit_imp <-
    }
   } else {
    y_dim <- 1
-   loss_fn <- torch::nn_mse_loss()
+   loss_fn <- function(input, target) {
+     nnf_mse_loss(input, target$view(c(-1,1)))
+   }
   }
 
   if (validation > 0) {
@@ -436,8 +438,8 @@ torch_mlp_reg_fit_imp <-
   # Optimize parameters
   for (epoch in 1:epochs) {
 
-
     param_values[epoch,] <- flatten_param(model$parameters)
+
 
    if (validation > 0) {
     pred <- model(dl_val$dataset$data$x)


### PR DESCRIPTION
There are 3 ways to compute the loss for binary classification problems yielding the same results. Using the 2nd here so we can output softmax/probability values.

``` r
library(torch)

x <- torch_randn(100, 2)
y <- torch_tensor(rep(c(1L, 2L), length.out = 100))

loss_1 <- nnf_cross_entropy(x, y)
loss_2 <- nnf_nll_loss(torch_log(nnf_softmax(x, 2)), y)
loss_3 <- nnf_binary_cross_entropy(
 nnf_softmax(x, 2)[,2]$view(c(-1, 1)), 
 (y == 2)$to(dtype = torch_float())$view(c(-1, 1))
)

loss_1
#> torch_tensor
#> 0.882054
#> [ CPUFloatType{} ]
loss_2
#> torch_tensor
#> 0.882054
#> [ CPUFloatType{} ]
loss_3
#> torch_tensor
#> 0.882054
#> [ CPUFloatType{} ]
```

<sup>Created on 2020-10-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>