### PR TITLE
changes for no-suggests

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check-hard.yaml
+
+permissions: read-all
+
+jobs:
+  check-no-suggests:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -36,7 +36,7 @@ brulee_plot <- function(object, ...) {
 #' vertical line shows the epoch with the best loss value.
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 #'  library(ggplot2)
 #'  library(recipes)
 #'  theme_set(theme_bw())

--- a/R/coef.R
+++ b/R/coef.R
@@ -28,7 +28,7 @@ brulee_coefs <- function(object, epoch = NULL, ...) {
 #' a list of arrays.
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "modeldata"))) {
 #'
 #'  data(ames, package = "modeldata")
 #'

--- a/R/linear_reg-fit.R
+++ b/R/linear_reg-fit.R
@@ -71,9 +71,12 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed()  & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 #'
 #'  ## -----------------------------------------------------------------------------
+#'
+#'  library(recipes)
+#'  library(yardstick)
 #'
 #'  data(ames, package = "modeldata")
 #'

--- a/R/linear_reg-predict.R
+++ b/R/linear_reg-predict.R
@@ -14,7 +14,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed("recipes")) {
 #'
 #'  data(ames, package = "modeldata")
 #'

--- a/R/logistic_reg-fit.R
+++ b/R/logistic_reg-fit.R
@@ -75,7 +75,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 #'
 #'  library(recipes)
 #'  library(yardstick)

--- a/R/logistic_reg-predict.R
+++ b/R/logistic_reg-predict.R
@@ -15,7 +15,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata")))) {
 #'
 #'   library(recipes)
 #'   library(yardstick)

--- a/R/mlp-fit.R
+++ b/R/mlp-fit.R
@@ -128,7 +128,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata")))) {
 #'
 #'  ## -----------------------------------------------------------------------------
 #'  # regression examples (increase # epochs to get better results)

--- a/R/mlp-predict.R
+++ b/R/mlp-predict.R
@@ -23,7 +23,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "modeldata")))) {
 #'  # regression example:
 #'
 #'  data(ames, package = "modeldata")

--- a/R/multinomial_reg-fit.R
+++ b/R/multinomial_reg-fit.R
@@ -74,7 +74,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 #'
 #'   library(recipes)
 #'   library(yardstick)

--- a/R/multinomial_reg-predict.R
+++ b/R/multinomial_reg-predict.R
@@ -15,7 +15,7 @@
 #'
 #' @examples
 #' \donttest{
-#' if (torch::torch_is_installed()) {
+#' if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata")))) {
 #'
 #'   library(recipes)
 #'   library(yardstick)

--- a/R/schedulers.R
+++ b/R/schedulers.R
@@ -33,28 +33,25 @@
 #'
 #' @seealso [brulee_mlp()]
 #' @examples
-#' library(ggplot2)
-#' library(dplyr)
-#' library(purrr)
+#' if (rlang::is_installed("purrr")) {
+#'  library(ggplot2)
+#'  library(dplyr)
+#'  library(purrr)
 #'
-#' iters <- 0:50
+#'  iters <- 0:50
 #'
-#' bind_rows(
-#'  tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_time), type = "decay_time"),
-#'  tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_expo), type = "decay_expo"),
-#'  tibble(epoch = iters, rate = map_dbl(iters, schedule_step), type = "step"),
-#'  tibble(epoch = iters, rate = map_dbl(iters, schedule_cyclic), type = "cyclic")
-#' ) %>%
-#'  ggplot(aes(epoch, rate)) +
-#'  geom_line() +
-#'  facet_wrap(~ type)
+#'  bind_rows(
+#'   tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_time), type = "decay_time"),
+#'   tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_expo), type = "decay_expo"),
+#'   tibble(epoch = iters, rate = map_dbl(iters, schedule_step), type = "step"),
+#'   tibble(epoch = iters, rate = map_dbl(iters, schedule_cyclic), type = "cyclic")
+#'  ) %>%
+#'   ggplot(aes(epoch, rate)) +
+#'   geom_line() +
+#'   facet_wrap(~ type)
 #'
-#' # ------------------------------------------------------------------------------
-#' # Use with neural network
+#' }
 #'
-#'
-
-
 #' @export
 
 schedule_decay_time <- function(epoch, initial = 0.1, decay = 1) {

--- a/man/brulee-autoplot.Rd
+++ b/man/brulee-autoplot.Rd
@@ -34,7 +34,7 @@ vertical line shows the epoch with the best loss value.
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
  library(ggplot2)
  library(recipes)
  theme_set(theme_bw())

--- a/man/brulee-coefs.Rd
+++ b/man/brulee-coefs.Rd
@@ -33,7 +33,7 @@ Extract Model Coefficients
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "modeldata"))) {
 
  data(ames, package = "modeldata")
 

--- a/man/brulee_linear_reg.Rd
+++ b/man/brulee_linear_reg.Rd
@@ -184,9 +184,12 @@ used in those packages.
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed()  & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 
  ## -----------------------------------------------------------------------------
+
+ library(recipes)
+ library(yardstick)
 
  data(ames, package = "modeldata")
 

--- a/man/brulee_logistic_reg.Rd
+++ b/man/brulee_logistic_reg.Rd
@@ -195,7 +195,7 @@ used in those packages.
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 
  library(recipes)
  library(yardstick)

--- a/man/brulee_mlp.Rd
+++ b/man/brulee_mlp.Rd
@@ -350,7 +350,7 @@ arguments to the schedulers can be passed via \code{...}.
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata")))) {
 
  ## -----------------------------------------------------------------------------
  # regression examples (increase # epochs to get better results)

--- a/man/brulee_multinomial_reg.Rd
+++ b/man/brulee_multinomial_reg.Rd
@@ -195,7 +195,7 @@ used in those packages.
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata"))) {
 
   library(recipes)
   library(yardstick)

--- a/man/predict.brulee_linear_reg.Rd
+++ b/man/predict.brulee_linear_reg.Rd
@@ -33,7 +33,7 @@ Predict from a \code{brulee_linear_reg}
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed("recipes")) {
 
  data(ames, package = "modeldata")
 

--- a/man/predict.brulee_logistic_reg.Rd
+++ b/man/predict.brulee_logistic_reg.Rd
@@ -34,7 +34,7 @@ Predict from a \code{brulee_logistic_reg}
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata")))) {
 
   library(recipes)
   library(yardstick)

--- a/man/predict.brulee_mlp.Rd
+++ b/man/predict.brulee_mlp.Rd
@@ -35,7 +35,7 @@ Predict from a \code{brulee_mlp}
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "modeldata")))) {
  # regression example:
 
  data(ames, package = "modeldata")

--- a/man/predict.brulee_multinomial_reg.Rd
+++ b/man/predict.brulee_multinomial_reg.Rd
@@ -34,7 +34,7 @@ Predict from a \code{brulee_multinomial_reg}
 }
 \examples{
 \donttest{
-if (torch::torch_is_installed()) {
+if (torch::torch_is_installed() & rlang::is_installed(c("recipes", "yardstick", "modeldata")))) {
 
   library(recipes)
   library(yardstick)

--- a/man/schedule_decay_time.Rd
+++ b/man/schedule_decay_time.Rd
@@ -65,25 +65,24 @@ The details for how the schedulers change the rates:
 }
 }
 \examples{
-library(ggplot2)
-library(dplyr)
-library(purrr)
+if (rlang::is_installed("purrr")) {
+ library(ggplot2)
+ library(dplyr)
+ library(purrr)
 
-iters <- 0:50
+ iters <- 0:50
 
-bind_rows(
- tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_time), type = "decay_time"),
- tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_expo), type = "decay_expo"),
- tibble(epoch = iters, rate = map_dbl(iters, schedule_step), type = "step"),
- tibble(epoch = iters, rate = map_dbl(iters, schedule_cyclic), type = "cyclic")
-) \%>\%
- ggplot(aes(epoch, rate)) +
- geom_line() +
- facet_wrap(~ type)
+ bind_rows(
+  tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_time), type = "decay_time"),
+  tibble(epoch = iters, rate = map_dbl(iters, schedule_decay_expo), type = "decay_expo"),
+  tibble(epoch = iters, rate = map_dbl(iters, schedule_step), type = "step"),
+  tibble(epoch = iters, rate = map_dbl(iters, schedule_cyclic), type = "cyclic")
+ ) \%>\%
+  ggplot(aes(epoch, rate)) +
+  geom_line() +
+  facet_wrap(~ type)
 
-# ------------------------------------------------------------------------------
-# Use with neural network
-
+}
 
 }
 \seealso{

--- a/tests/testthat/test-schedulers.R
+++ b/tests/testthat/test-schedulers.R
@@ -1,6 +1,8 @@
-library(purrr)
+
 
 test_that("scheduling functions", {
+ skip_if_not_installed("purrr")
+ library(purrr)
 
  x <- 0:100
 


### PR DESCRIPTION
Add a GH workflow that only directly installs "hard" dependencies, i.e. Depends, Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never installed, with the exception of testthat, knitr, and rmarkdown. The cache is never used to avoid accidentally restoring a cache containing a suggested dependency.