### PR TITLE
gradient clipping for numerical stability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # brulee (development version)
 
 * Transition from the magrittr pipe to the base R pipe.
+* `brulee_mlp()` has two additional parameters, `grad_value_clip` and `grad_value_clip`, that prevent overflow errors (i.e., error messages of `"Loss is NaN at epoch x Training is stopped."`).
 
 # brulee (0.5.0)
 

--- a/man/brulee_mlp.Rd
+++ b/man/brulee_mlp.Rd
@@ -36,6 +36,8 @@ brulee_mlp(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -57,6 +59,8 @@ brulee_mlp(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -78,6 +82,8 @@ brulee_mlp(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -99,6 +105,8 @@ brulee_mlp(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -126,6 +134,8 @@ brulee_mlp_two_layer(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -149,6 +159,8 @@ brulee_mlp_two_layer(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -172,6 +184,8 @@ brulee_mlp_two_layer(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -195,6 +209,8 @@ brulee_mlp_two_layer(x, ...)
   batch_size = NULL,
   class_weights = NULL,
   stop_iter = 5,
+  grad_value_clip = Inf,
+  grad_norm_clip = Inf,
   verbose = FALSE,
   ...
 )
@@ -276,6 +292,11 @@ and all other classes receive a weight of one.
 
 \item{stop_iter}{A non-negative integer for how many iterations with no
 improvement before stopping.}
+
+\item{grad_norm_clip, grad_value_clip}{Two numeric values, possibly \code{Inf},
+that prevents the gradient's values or norm(s) from exceeding the specified
+value. This can be helpful if training stops early with the message that
+\code{"Loss is NaN at epoch x Training is stopped."}}
 
 \item{verbose}{A logical that prints out the iteration history.}
 


### PR DESCRIPTION
Closes #73

There are occasions where the model parameters lead to overflow when computing the loss function: 

``` r
library(brulee)
library(modeldata)
#> 
#> Attaching package: 'modeldata'
#> The following object is masked from 'package:datasets':
#> 
#>     penguins

i <- 25691
set.seed(i)
data_tr <- sim_logistic(200, ~ .1 + 2 * A - 3 * B + 1 * A *B, corr = .7)

set.seed(i+1)
mlp_fit <- brulee_mlp(class ~ ., data = data_tr, hidden_units = 10, epochs = 35,
                      stop_iter = Inf, verbose = TRUE)
#> epoch: 1 learn rate 0.01 Loss: 0.581
#> epoch: 2 learn rate 0.01 Loss: 0.492
#> epoch: 3 learn rate 0.01 Loss: 0.482
#> epoch: 4 learn rate 0.01 Loss: 0.474
#> epoch: 5 learn rate 0.01 Loss: 0.47
#> epoch: 6 learn rate 0.01 Loss: 0.465
#> epoch: 7 learn rate 0.01 Loss: 0.466 ✖
#> epoch: 8 learn rate 0.01 Loss: 0.461
#> epoch: 9 learn rate 0.01 Loss: 0.45
#> epoch: 10 learn rate 0.01 Loss: 0.45
#> epoch: 11 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 12 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 13 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 14 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 15 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 16 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 17 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 18 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 19 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 20 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 21 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 22 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 23 learn rate 0.01 Loss: 0.449
#> epoch: 24 learn rate 0.01 Loss: 0.45 ✖
#> epoch: 25 learn rate 0.01 Loss: 0.448
#> epoch: 26 learn rate 0.01 Loss: 0.448 ✖
#> epoch: 27 learn rate 0.01 Loss: 0.449 ✖
#> epoch: 28 learn rate 0.01 Loss: 0.448
#> epoch: 29 learn rate 0.01 Loss: 0.449 ✖
#> epoch: 30 learn rate 0.01 Loss: 0.448 ✖
#> epoch: 31 learn rate 0.01 Loss: 0.448
#> Warning: Loss is NaN at epoch 32. Training is stopped.
```

<sup>Created on 2025-07-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This PR adds two new parameters that can prevent the gradient values or their norms from becoming too large: 

``` r
library(brulee)
library(modeldata)
#> 
#> Attaching package: 'modeldata'
#> The following object is masked from 'package:datasets':
#> 
#>     penguins

i <- 25691
set.seed(i)
data_tr <- sim_logistic(200, ~ .1 + 2 * A - 3 * B + 1 * A *B, corr = .7)

set.seed(i+1)
mlp_fit <- brulee_mlp(class ~ ., data = data_tr, hidden_units = 10, epochs = 35, 
                      grad_norm_clip = 1 / 50, stop_iter = Inf, verbose = TRUE)
#> epoch: 1 learn rate 0.01 Loss: 0.783
#> epoch: 2 learn rate 0.01 Loss: 0.78
#> epoch: 3 learn rate 0.01 Loss: 0.777
#> epoch: 4 learn rate 0.01 Loss: 0.775
#> epoch: 5 learn rate 0.01 Loss: 0.772
#> epoch: 6 learn rate 0.01 Loss: 0.769
#> epoch: 7 learn rate 0.01 Loss: 0.767
#> epoch: 8 learn rate 0.01 Loss: 0.764
#> epoch: 9 learn rate 0.01 Loss: 0.761
#> epoch: 10 learn rate 0.01 Loss: 0.759
#> epoch: 11 learn rate 0.01 Loss: 0.756
#> epoch: 12 learn rate 0.01 Loss: 0.753
#> epoch: 13 learn rate 0.01 Loss: 0.751
#> epoch: 14 learn rate 0.01 Loss: 0.748
#> epoch: 15 learn rate 0.01 Loss: 0.746
#> epoch: 16 learn rate 0.01 Loss: 0.743
#> epoch: 17 learn rate 0.01 Loss: 0.74
#> epoch: 18 learn rate 0.01 Loss: 0.738
#> epoch: 19 learn rate 0.01 Loss: 0.735
#> epoch: 20 learn rate 0.01 Loss: 0.733
#> epoch: 21 learn rate 0.01 Loss: 0.73
#> epoch: 22 learn rate 0.01 Loss: 0.728
#> epoch: 23 learn rate 0.01 Loss: 0.725
#> epoch: 24 learn rate 0.01 Loss: 0.723
#> epoch: 25 learn rate 0.01 Loss: 0.721
#> epoch: 26 learn rate 0.01 Loss: 0.718
#> epoch: 27 learn rate 0.01 Loss: 0.716
#> epoch: 28 learn rate 0.01 Loss: 0.713
#> epoch: 29 learn rate 0.01 Loss: 0.711
#> epoch: 30 learn rate 0.01 Loss: 0.709
#> epoch: 31 learn rate 0.01 Loss: 0.706
#> epoch: 32 learn rate 0.01 Loss: 0.704
#> epoch: 33 learn rate 0.01 Loss: 0.702
#> epoch: 34 learn rate 0.01 Loss: 0.7
#> epoch: 35 learn rate 0.01 Loss: 0.697
```

<sup>Created on 2025-07-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>