### PR TITLE
limit precision for class weights in `print()`

### DIFF
--- a/R/0_utils.R
+++ b/R/0_utils.R
@@ -22,7 +22,7 @@ brulee_print <- function(x, ...) {
       paste0(
         lvl,
         "=",
-        format(x$parameters$class_weights),
+        format(x$parameters$class_weights, digits = 3),
         collapse = ", "
       ),
       "\n"


### PR DESCRIPTION
Limited sig digits to 3 for class weights output in `print()`. Chose 3 to match other outputs in `print()`.

Fixes #104 