### PR TITLE
Target token

### DIFF
--- a/R/saint-fit.R
+++ b/R/saint-fit.R
@@ -24,11 +24,12 @@
 #' @param dropout_attn A number in `[0, 1)` for the dropout rate applied to
 #'   attention weights during training.
 #' @param row_attention_on_predict A logical value. Should row (inter-sample)
-#'   attention be applied during prediction? Default is `FALSE`. When `FALSE`,
-#'   row attention is only used during training and predictions use column
-#'   attention only — this ensures that predictions for a given row are
-#'   independent of what other rows are in the prediction set. This is only
-#'   relevant when `attention_type` is `"row"` or `"both"`.
+#'   attention be applied during prediction? Default is `TRUE`, matching the
+#'   training-time behavior. When `FALSE`, row attention is bypassed at
+#'   predict time so that predictions for a given row do not depend on what
+#'   other rows are in the prediction set; column attention is used on its
+#'   own. This is only relevant when `attention_type` is `"row"` or
+#'   `"both"`.
 #' @param hidden_units An integer vector for the number of units in optional
 #'   hidden layers between the transformer backbone and the output head.
 #'   When `NULL` (the default), no hidden layers are added and the pooled
@@ -58,7 +59,8 @@
 #' 1. **Embedding layer**: Categorical features are mapped through per-feature
 #'    embedding tables. Continuous features are passed through per-feature MLPs
 #'    (1 -> 100 -> `num_embedding`). These initial embeddings are per-feature;
-#'    there is a distinct embedding MLP for each predictor.
+#'    there is a distinct embedding MLP for each predictor. Also, see the
+#'    "Target Token Pooling" section below.
 #' 2. **Transformer backbone**: A stack of `num_attn_blocks` transformer layers.
 #'    Each layer contains multi-head self-attention followed by a feed-forward
 #'    network with GeGLU activation. For `attention_type = "both"`, each block
@@ -123,9 +125,14 @@
 #' Row attention computations adjust the internal embeddings based on the rows
 #' that are available at any given time. During training, the other rows in the
 #' batch are used to compute attention. After training, when `predict()` is
-#' called, the default behavior is to bypass row attention. This is because the
-#' predictions would depend on the other data available at the time. If this is
-#' what you want, set `row_attention_on_predict` to `TRUE`.
+#' called, the default behavior is to keep row attention on, mirroring the
+#' training-time computation. Because row attention is computed across the
+#' samples present in a given call, predictions for a row depend on what
+#' other rows are passed alongside it. To get batch-independent predictions
+#' (where the prediction for a given row is the same regardless of what
+#' other rows are in the input), set `row_attention_on_predict` to `FALSE`;
+#' row attention is then bypassed at predict time and column attention is
+#' used on its own.
 #'
 #' ## Learning Rates
 #'
@@ -247,7 +254,7 @@ brulee_saint.data.frame <- function(
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -312,7 +319,7 @@ brulee_saint.matrix <- function(
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -377,7 +384,7 @@ brulee_saint.formula <- function(
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -446,7 +453,7 @@ brulee_saint.recipe <- function(
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -793,7 +800,7 @@ saint_fit_imp <- function(
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = NULL,
   hidden_activations = NULL,
   penalty = 0.001,

--- a/R/saint-fit.R
+++ b/R/saint-fit.R
@@ -31,7 +31,7 @@
 #'   relevant when `attention_type` is `"row"` or `"both"`.
 #' @param hidden_units An integer vector for the number of units in optional
 #'   hidden layers between the transformer backbone and the output head.
-#'   When `NULL` (the default), no hidden layers are added and the flattened
+#'   When `NULL` (the default), no hidden layers are added and the pooled
 #'   transformer output is projected directly to the output.
 #' @param hidden_activations A character vector of activation functions for the
 #'   hidden layers. Must be the same length as `hidden_units` or a single value
@@ -41,6 +41,14 @@
 #' @param dropout_last A number in `[0, 1)` for the dropout rate applied
 #'   between the last hidden layer and the output head. Only has effect when
 #'   `hidden_units` is not `NULL`. Default is 0 (no dropout).
+#' @param use_target_token A logical value. When `TRUE` (the default), a
+#'   learnable target token (`[CLS]` in the SAINT paper) is prepended to
+#'   each sample's feature sequence and only its final-layer embedding is
+#'   fed to the head. This matches the architecture described in the SAINT
+#'   paper (Section 3 and Figure 1); see the **Target Token Pooling**
+#'   section in **Details**. When `FALSE`, the head instead consumes the
+#'   concatenation of every feature token, which matches the SAINT
+#'   reference implementation at <https://github.com/somepago/saint>.
 #' @details
 #'
 #' ## Architecture
@@ -56,11 +64,17 @@
 #'    network with GeGLU activation. For `attention_type = "both"`, each block
 #'    alternates between column attention (across features) and row attention
 #'    (across samples within the batch).
-#' 3. **Output head**: Flattens the transformer output and projects through
+#' 3. **Output head**: Pools the transformer output (either the target
+#'    token's embedding or the flattened concatenation of all feature
+#'    embeddings, controlled by `use_target_token`) and projects it through
 #'    optional hidden layers to the output dimension.
 #'
 #' There is a `summary()` methods that can provide details of the architecture
 #' for a specific model fit.
+#'
+#' Differences in this implementation and the orignal paper:
+#'
+#'  - Pretraining isn't supported.
 #'
 #' ## Attention Types
 #'
@@ -71,6 +85,38 @@
 #'   then applies attention across all samples in the batch.
 #' - **Both** (`"both"`): Alternates between column and row attention in each
 #'   transformer block. This is the full SAINT model.
+#'
+#' ## Target Token Pooling
+#'
+#' Borrowing from BERT, SAINT prepends a learnable target token (the
+#' paper calls it `[CLS]`) to each sample's feature sequence before the
+#' transformer. With embeddings `E(x_i^{(1)}), ..., E(x_i^{(n)})` for the
+#' `n` predictors of sample `i`, the input sequence becomes
+#'
+#' `[target, E(x_i^{(1)}), E(x_i^{(2)}), ..., E(x_i^{(n)})]`
+#'
+#' giving `n + 1` tokens of dimension `num_embedding`. The target token has
+#' no input value; it is a free parameter of the model that is trained
+#' alongside the rest of the network. Column attention lets every feature
+#' token attend to the target and vice versa, so the target slot accumulates
+#' a contextual summary of the sample. When `attention_type` is `"row"` or
+#' `"both"`, inter-sample attention sees the full `n + 1` token sequence per
+#' sample, so the target slot also exchanges information across samples in
+#' the batch.
+#'
+#' After the transformer backbone, the head reads _only_ the final-layer
+#' embedding of the target token (the first position) and feeds it through
+#' the optional `hidden_units` MLP and the output layer. This is what the
+#' paper describes in Figure 1: "We take the contextual embeddings from
+#' SAINT and pass only the embedding correspond to the CLS token through an
+#' MLP to obtain the final prediction."
+#'
+#' With `use_target_token = FALSE`, no target token is added and the head
+#' instead consumes the concatenation of all `n` feature tokens. That
+#' option is provided because the SAINT reference Python implementation
+#' (<https://github.com/somepago/saint>) departs from the paper and uses
+#' flatten-pooling; it is kept available for compatibility with that code
+#' path and for users who want the original brulee behavior.
 #'
 #' ## Row Attention at Prediction Time
 #'
@@ -216,6 +262,7 @@ brulee_saint.data.frame <- function(
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 ) {
   processed <- hardhat::mold(x, y)
@@ -245,6 +292,7 @@ brulee_saint.data.frame <- function(
     stop_iter = stop_iter,
     verbose = verbose,
     device = device,
+    use_target_token = use_target_token,
     ...
   )
 }
@@ -279,6 +327,7 @@ brulee_saint.matrix <- function(
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 ) {
   processed <- hardhat::mold(x, y)
@@ -308,6 +357,7 @@ brulee_saint.matrix <- function(
     stop_iter = stop_iter,
     verbose = verbose,
     device = device,
+    use_target_token = use_target_token,
     ...
   )
 }
@@ -342,6 +392,7 @@ brulee_saint.formula <- function(
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 ) {
   processed <- hardhat::mold(
@@ -375,6 +426,7 @@ brulee_saint.formula <- function(
     stop_iter = stop_iter,
     verbose = verbose,
     device = device,
+    use_target_token = use_target_token,
     ...
   )
 }
@@ -409,6 +461,7 @@ brulee_saint.recipe <- function(
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 ) {
   processed <- hardhat::mold(x, data)
@@ -438,6 +491,7 @@ brulee_saint.recipe <- function(
     stop_iter = stop_iter,
     verbose = verbose,
     device = device,
+    use_target_token = use_target_token,
     ...
   )
 }
@@ -470,6 +524,7 @@ brulee_saint_bridge <- function(
   stop_iter,
   verbose,
   device,
+  use_target_token,
   ...,
   call = rlang::caller_env()
 ) {
@@ -489,6 +544,7 @@ brulee_saint_bridge <- function(
     num_attn_blocks = num_attn_blocks,
     dropout_attn = dropout_attn,
     dropout_hidden = dropout_hidden,
+    use_target_token = use_target_token,
     call = call
   )
 
@@ -580,6 +636,7 @@ brulee_saint_bridge <- function(
     stop_iter = stop_iter,
     verbose = verbose,
     device = device,
+    use_target_token = saint_validated$use_target_token,
     ...
   )
 
@@ -607,6 +664,7 @@ validate_saint_args <- function(
   num_attn_blocks,
   dropout_attn,
   dropout_hidden,
+  use_target_token,
   call = rlang::caller_env()
 ) {
   if (is.numeric(num_embedding) & !is.integer(num_embedding)) {
@@ -632,6 +690,8 @@ validate_saint_args <- function(
     )
   }
 
+  check_bool(use_target_token, call = call)
+
   check_double(dropout_attn, single = TRUE, 0, call = call)
   if (dropout_attn >= 1) {
     cli::cli_abort("{.arg dropout_attn} must be less than 1.", call = call)
@@ -648,7 +708,8 @@ validate_saint_args <- function(
     num_attn_heads = num_attn_heads,
     num_attn_blocks = num_attn_blocks,
     dropout_attn = dropout_attn,
-    dropout_hidden = dropout_hidden
+    dropout_hidden = dropout_hidden,
+    use_target_token = use_target_token
   )
 }
 
@@ -746,6 +807,7 @@ saint_fit_imp <- function(
   stop_iter = 5,
   verbose = FALSE,
   device = "cpu",
+  use_target_token = TRUE,
   ...
 ) {
   start_seed <- sample.int(10^5, 1)
@@ -845,7 +907,8 @@ saint_fit_imp <- function(
     dropout_last = dropout_last,
     hidden_units = hidden_units,
     hidden_activations = hidden_activations,
-    y_dim = y_dim
+    y_dim = y_dim,
+    use_target_token = use_target_token
   )
   model$to(device = device)
 
@@ -957,6 +1020,7 @@ saint_fit_imp <- function(
         momentum = momentum,
         stop_iter = stop_iter,
         sched = rate_schedule,
+        use_target_token = use_target_token,
         sched_opt = list(...)
       )
     )
@@ -1384,10 +1448,16 @@ saint_rowcol_transformer_module <- torch::nn_module(
 
 saint_embedding_module <- torch::nn_module(
   "saint_embedding",
-  initialize = function(pred_lvls, n_continuous, num_embedding) {
+  initialize = function(
+    pred_lvls,
+    n_continuous,
+    num_embedding,
+    use_target_token = FALSE
+  ) {
     self$n_cat <- length(pred_lvls)
     self$n_cont <- n_continuous
     self$num_embedding <- num_embedding
+    self$use_target_token <- isTRUE(use_target_token)
 
     if (self$n_cat > 0) {
       self$cat_embeddings <- torch::nn_module_list(lapply(
@@ -1413,6 +1483,12 @@ saint_embedding_module <- torch::nn_module(
         }
       ))
     }
+
+    if (self$use_target_token) {
+      self$target_token <- torch::nn_parameter(
+        torch::torch_randn(1L, 1L, num_embedding)
+      )
+    }
   },
   forward = function(x_cat = NULL, x_cont = NULL) {
     parts <- list()
@@ -1433,7 +1509,15 @@ saint_embedding_module <- torch::nn_module(
       parts <- c(parts, list(torch::torch_stack(cont_embeds, dim = 2L)))
     }
 
-    torch::torch_cat(parts, dim = 2L)
+    feats <- torch::torch_cat(parts, dim = 2L)
+
+    if (self$use_target_token) {
+      batch <- feats$shape[1]
+      tgt <- self$target_token$expand(c(batch, 1L, self$num_embedding))
+      feats <- torch::torch_cat(list(tgt, feats), dim = 2L)
+    }
+
+    feats
   }
 )
 
@@ -1451,16 +1535,20 @@ saint_module <- torch::nn_module(
     dropout_last,
     hidden_units,
     hidden_activations,
-    y_dim
+    y_dim,
+    use_target_token = FALSE
   ) {
     num_features <- length(pred_lvls) + n_continuous
     self$num_features <- num_features
     self$num_embedding <- num_embedding
+    self$use_target_token <- isTRUE(use_target_token)
+    seq_len <- num_features + as.integer(self$use_target_token)
 
     self$embedding <- saint_embedding_module(
       pred_lvls = pred_lvls,
       n_continuous = n_continuous,
-      num_embedding = num_embedding
+      num_embedding = num_embedding,
+      use_target_token = self$use_target_token
     )
 
     if (attention_type == "column") {
@@ -1475,7 +1563,7 @@ saint_module <- torch::nn_module(
     } else {
       self$backbone <- saint_rowcol_transformer_module(
         dim = num_embedding,
-        nfeats = num_features,
+        nfeats = seq_len,
         depth = num_attn_blocks,
         heads = num_attn_heads,
         dim_head = 16L,
@@ -1485,11 +1573,15 @@ saint_module <- torch::nn_module(
       )
     }
 
-    flattened_dim <- num_features * num_embedding
+    head_input_dim <- if (self$use_target_token) {
+      num_embedding
+    } else {
+      seq_len * num_embedding
+    }
 
     if (!is.null(hidden_units)) {
       hidden_layers <- list()
-      input_dim <- flattened_dim
+      input_dim <- head_input_dim
       for (i in seq_along(hidden_units)) {
         hidden_layers[[length(hidden_layers) + 1]] <-
           torch::nn_linear(input_dim, hidden_units[i])
@@ -1510,7 +1602,7 @@ saint_module <- torch::nn_module(
     } else {
       self$hidden <- NULL
       self$hidden_drop <- NULL
-      self$output_head <- torch::nn_linear(flattened_dim, y_dim)
+      self$output_head <- torch::nn_linear(head_input_dim, y_dim)
     }
 
     self$y_dim <- y_dim
@@ -1518,17 +1610,22 @@ saint_module <- torch::nn_module(
   forward = function(x_cat = NULL, x_cont = NULL) {
     embeds <- self$embedding(x_cat, x_cont)
     h <- self$backbone(embeds)
-    h_flat <- h$reshape(c(h$shape[1], -1L))
+
+    if (self$use_target_token) {
+      h_pooled <- h[, 1L, ]
+    } else {
+      h_pooled <- h$reshape(c(h$shape[1], -1L))
+    }
 
     if (!is.null(self$hidden)) {
-      h_flat <- self$hidden(h_flat)
+      h_pooled <- self$hidden(h_pooled)
       if (!is.null(self$hidden_drop)) {
-        h_flat <- self$hidden_drop(h_flat)
+        h_pooled <- self$hidden_drop(h_pooled)
       }
     }
     # Classification returns raw logits; softmax is applied at predict time
     # so the loss can use nnf_cross_entropy (numerically stable).
-    self$output_head(h_flat)
+    self$output_head(h_pooled)
   }
 )
 

--- a/R/summary.R
+++ b/R/summary.R
@@ -345,6 +345,7 @@ summary.brulee_saint <- function(object, ...) {
   num_attn_heads <- object$parameters$num_attn_heads
   num_attn_blocks <- object$parameters$num_attn_blocks
   attention_type <- object$parameters$attention_type
+  use_target_token <- isTRUE(object$parameters$use_target_token)
 
   total <- 0L
   cat(cli::style_bold("SAINT architecture"), "\n", sep = "")
@@ -363,6 +364,8 @@ summary.brulee_saint <- function(object, ...) {
     attention_type,
     " | embedding dim: ",
     num_embedding,
+    " | target token: ",
+    use_target_token,
     "\n\n",
     sep = ""
   )
@@ -379,6 +382,15 @@ summary.brulee_saint <- function(object, ...) {
   # --- Embedding layer ---
   cat(cli::style_bold("Embedding layer"), "\n", sep = "")
   emb <- module$embedding
+
+  if (isTRUE(emb$use_target_token)) {
+    n_par_target <- as.integer(prod(emb$target_token$shape))
+    total <- total + n_par_target
+    cat(fmt_row(
+      paste0("Target token (1 x ", num_embedding, ")"),
+      n_par_target
+    ))
+  }
 
   if (emb$n_cat > 0) {
     for (i in seq_len(emb$n_cat)) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -9,6 +9,7 @@ AutoInt
 Babenko
 Bruss
 CIKM
+CLS
 CMD
 CUDA
 Cham
@@ -55,6 +56,7 @@ Shchur
 Shi
 Somepalli
 Springer
+ViT
 Xiao
 Xu
 Zeiler
@@ -76,6 +78,7 @@ flexability
 funder
 https
 interpretability
+learnable
 magrittr
 mlp
 multilayer

--- a/man/brulee_saint.Rd
+++ b/man/brulee_saint.Rd
@@ -39,6 +39,7 @@ brulee_saint(x, ...)
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 )
 
@@ -68,6 +69,7 @@ brulee_saint(x, ...)
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 )
 
@@ -97,6 +99,7 @@ brulee_saint(x, ...)
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 )
 
@@ -126,6 +129,7 @@ brulee_saint(x, ...)
   stop_iter = 5,
   verbose = FALSE,
   device = NULL,
+  use_target_token = TRUE,
   ...
 )
 }
@@ -194,7 +198,7 @@ relevant when \code{attention_type} is \code{"row"} or \code{"both"}.}
 
 \item{hidden_units}{An integer vector for the number of units in optional
 hidden layers between the transformer backbone and the output head.
-When \code{NULL} (the default), no hidden layers are added and the flattened
+When \code{NULL} (the default), no hidden layers are added and the pooled
 transformer output is projected directly to the output.}
 
 \item{hidden_activations}{A character vector of activation functions for the
@@ -252,6 +256,15 @@ improvement before stopping.}
 \code{"cpu"} or \code{"cuda"} for GPU). If \code{NULL}, the function will use the GPU if
 available, otherwise CPU. See \link{training_efficiency}.}
 
+\item{use_target_token}{A logical value. When \code{TRUE} (the default), a
+learnable target token (\verb{[CLS]} in the SAINT paper) is prepended to
+each sample's feature sequence and only its final-layer embedding is
+fed to the head. This matches the architecture described in the SAINT
+paper (Section 3 and Figure 1); see the \strong{Target Token Pooling}
+section in \strong{Details}. When \code{FALSE}, the head instead consumes the
+concatenation of every feature token, which matches the SAINT
+reference implementation at \url{https://github.com/somepago/saint}.}
+
 \item{formula}{A formula specifying the outcome term(s) on the left-hand side,
 and the predictor term(s) on the right-hand side.}
 
@@ -296,12 +309,19 @@ Each layer contains multi-head self-attention followed by a feed-forward
 network with GeGLU activation. For \code{attention_type = "both"}, each block
 alternates between column attention (across features) and row attention
 (across samples within the batch).
-\item \strong{Output head}: Flattens the transformer output and projects through
+\item \strong{Output head}: Pools the transformer output (either the target
+token's embedding or the flattened concatenation of all feature
+embeddings, controlled by \code{use_target_token}) and projects it through
 optional hidden layers to the output dimension.
 }
 
 There is a \code{summary()} methods that can provide details of the architecture
 for a specific model fit.
+
+Differences in this implementation and the orignal paper:
+\itemize{
+\item Pretraining isn't supported.
+}
 }
 
 \subsection{Attention Types}{
@@ -314,6 +334,39 @@ then applies attention across all samples in the batch.
 \item \strong{Both} (\code{"both"}): Alternates between column and row attention in each
 transformer block. This is the full SAINT model.
 }
+}
+
+\subsection{Target Token Pooling}{
+
+Borrowing from BERT, SAINT prepends a learnable target token (the
+paper calls it \verb{[CLS]}) to each sample's feature sequence before the
+transformer. With embeddings \verb{E(x_i^\{(1)\}), ..., E(x_i^\{(n)\})} for the
+\code{n} predictors of sample \code{i}, the input sequence becomes
+
+\verb{[target, E(x_i^\{(1)\}), E(x_i^\{(2)\}), ..., E(x_i^\{(n)\})]}
+
+giving \code{n + 1} tokens of dimension \code{num_embedding}. The target token has
+no input value; it is a free parameter of the model that is trained
+alongside the rest of the network. Column attention lets every feature
+token attend to the target and vice versa, so the target slot accumulates
+a contextual summary of the sample. When \code{attention_type} is \code{"row"} or
+\code{"both"}, inter-sample attention sees the full \code{n + 1} token sequence per
+sample, so the target slot also exchanges information across samples in
+the batch.
+
+After the transformer backbone, the head reads \emph{only} the final-layer
+embedding of the target token (the first position) and feeds it through
+the optional \code{hidden_units} MLP and the output layer. This is what the
+paper describes in Figure 1: "We take the contextual embeddings from
+SAINT and pass only the embedding correspond to the CLS token through an
+MLP to obtain the final prediction."
+
+With \code{use_target_token = FALSE}, no target token is added and the head
+instead consumes the concatenation of all \code{n} feature tokens. That
+option is provided because the SAINT reference Python implementation
+(\url{https://github.com/somepago/saint}) departs from the paper and uses
+flatten-pooling; it is kept available for compatibility with that code
+path and for users who want the original brulee behavior.
 }
 
 \subsection{Row Attention at Prediction Time}{

--- a/man/brulee_saint.Rd
+++ b/man/brulee_saint.Rd
@@ -24,7 +24,7 @@ brulee_saint(x, ...)
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -54,7 +54,7 @@ brulee_saint(x, ...)
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -84,7 +84,7 @@ brulee_saint(x, ...)
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -114,7 +114,7 @@ brulee_saint(x, ...)
   dropout_attn = 0.1,
   dropout_hidden = 0.1,
   dropout_last = 0,
-  row_attention_on_predict = FALSE,
+  row_attention_on_predict = TRUE,
   hidden_units = 5,
   hidden_activations = "relu",
   penalty = 0.001,
@@ -190,11 +190,12 @@ between the last hidden layer and the output head. Only has effect when
 \code{hidden_units} is not \code{NULL}. Default is 0 (no dropout).}
 
 \item{row_attention_on_predict}{A logical value. Should row (inter-sample)
-attention be applied during prediction? Default is \code{FALSE}. When \code{FALSE},
-row attention is only used during training and predictions use column
-attention only — this ensures that predictions for a given row are
-independent of what other rows are in the prediction set. This is only
-relevant when \code{attention_type} is \code{"row"} or \code{"both"}.}
+attention be applied during prediction? Default is \code{TRUE}, matching the
+training-time behavior. When \code{FALSE}, row attention is bypassed at
+predict time so that predictions for a given row do not depend on what
+other rows are in the prediction set; column attention is used on its
+own. This is only relevant when \code{attention_type} is \code{"row"} or
+\code{"both"}.}
 
 \item{hidden_units}{An integer vector for the number of units in optional
 hidden layers between the transformer backbone and the output head.
@@ -303,7 +304,8 @@ The SAINT architecture has three stages:
 \item \strong{Embedding layer}: Categorical features are mapped through per-feature
 embedding tables. Continuous features are passed through per-feature MLPs
 (1 -> 100 -> \code{num_embedding}). These initial embeddings are per-feature;
-there is a distinct embedding MLP for each predictor.
+there is a distinct embedding MLP for each predictor. Also, see the
+"Target Token Pooling" section below.
 \item \strong{Transformer backbone}: A stack of \code{num_attn_blocks} transformer layers.
 Each layer contains multi-head self-attention followed by a feed-forward
 network with GeGLU activation. For \code{attention_type = "both"}, each block
@@ -374,9 +376,14 @@ path and for users who want the original brulee behavior.
 Row attention computations adjust the internal embeddings based on the rows
 that are available at any given time. During training, the other rows in the
 batch are used to compute attention. After training, when \code{predict()} is
-called, the default behavior is to bypass row attention. This is because the
-predictions would depend on the other data available at the time. If this is
-what you want, set \code{row_attention_on_predict} to \code{TRUE}.
+called, the default behavior is to keep row attention on, mirroring the
+training-time computation. Because row attention is computed across the
+samples present in a given call, predictions for a row depend on what
+other rows are passed alongside it. To get batch-independent predictions
+(where the prediction for a given row is the same regardless of what
+other rows are in the input), set \code{row_attention_on_predict} to \code{FALSE};
+row attention is then bypassed at predict time and column attention is
+used on its own.
 }
 
 \subsection{Learning Rates}{

--- a/tests/testthat/_snaps/saint.md
+++ b/tests/testthat/_snaps/saint.md
@@ -1,0 +1,9 @@
+# saint use_target_token argument is validated
+
+    Code
+      brulee_saint(y ~ ., data = single_series, epochs = 2, use_target_token = "nope",
+      verbose = FALSE, device = "cpu")
+    Condition
+      Error in `brulee_saint()`:
+      ! `use_target_token` must be `TRUE` or `FALSE`, not the string "nope".
+

--- a/tests/testthat/test-saint.R
+++ b/tests/testthat/test-saint.R
@@ -267,7 +267,7 @@ test_that("saint with colrow attention type (default)", {
 # ------------------------------------------------------------------------------
 # row_attention_on_predict tests
 
-test_that("saint row_attention_on_predict=FALSE (default) gives batch-independent predictions", {
+test_that("saint row_attention_on_predict=FALSE gives batch-independent predictions", {
   skip_on_cran()
   skip_if_not_installed("torch")
 

--- a/tests/testthat/test-saint.R
+++ b/tests/testthat/test-saint.R
@@ -603,3 +603,97 @@ test_that("saint autoplot works", {
   p <- ggplot2::autoplot(fit)
   expect_s3_class(p, "ggplot")
 })
+
+# ------------------------------------------------------------------------------
+# Target token (CLS) pooling tests
+
+test_that("saint use_target_token=FALSE fits and predicts (column attention)", {
+  skip_on_cran()
+  skip_if_not_installed("torch")
+
+  set.seed(1)
+  n <- 80
+  parabolic <- data.frame(
+    x1 = rnorm(n),
+    x2 = rnorm(n),
+    x3 = rnorm(n)
+  )
+  parabolic$y <- parabolic$x1 + 2 * parabolic$x2 + rnorm(n, sd = 0.2)
+
+  set.seed(1)
+  torch::torch_manual_seed(1)
+  fit <- brulee_saint(
+    y ~ .,
+    data = parabolic,
+    epochs = 5,
+    attention_type = "column",
+    use_target_token = FALSE,
+    verbose = FALSE,
+    device = "cpu"
+  )
+
+  expect_s3_class(fit, "brulee_saint")
+  expect_false(fit$parameters$use_target_token)
+
+  pred <- predict(fit, parabolic)
+  expect_equal(nrow(pred), n)
+  expect_true(all(is.finite(pred$.pred)))
+})
+
+test_that("saint use_target_token=TRUE (default) works with row+column attention", {
+  skip_on_cran()
+  skip_if_not_installed("torch")
+
+  set.seed(1)
+  n <- 80
+  parabolic <- data.frame(
+    x1 = rnorm(n),
+    x2 = rnorm(n),
+    g = factor(sample(c("a", "b"), n, replace = TRUE))
+  )
+  parabolic$y <- factor(
+    ifelse(parabolic$x1 + rnorm(n, sd = 0.5) > 0, "pos", "neg")
+  )
+
+  set.seed(1)
+  torch::torch_manual_seed(1)
+  fit <- brulee_saint(
+    y ~ .,
+    data = parabolic,
+    epochs = 5,
+    attention_type = "both",
+    num_attn_blocks = 1L,
+    verbose = FALSE,
+    device = "cpu"
+  )
+
+  expect_s3_class(fit, "brulee_saint")
+  expect_true(fit$parameters$use_target_token)
+
+  pred_prob <- predict(fit, parabolic, type = "prob")
+  expect_equal(nrow(pred_prob), n)
+  row_sums <- rowSums(as.matrix(pred_prob))
+  expect_true(all(abs(row_sums - 1) < 1e-5))
+})
+
+test_that("saint use_target_token argument is validated", {
+  skip_on_cran()
+  skip_if_not_installed("torch")
+
+  set.seed(1)
+  n <- 30
+  single_series <- data.frame(x1 = rnorm(n), x2 = rnorm(n))
+  single_series$y <- single_series$x1 + rnorm(n, sd = 0.1)
+
+  expect_snapshot(
+    error = TRUE,
+    brulee_saint(
+      y ~ .,
+      data = single_series,
+      epochs = 2,
+      use_target_token = "nope",
+      verbose = FALSE,
+      device = "cpu"
+    )
+  )
+})


### PR DESCRIPTION
Added the target token feature (called a `[cls]` token in the original paper). We based our initial implementation on the Python package, which did not include this feature. 