### PR TITLE
Fixes #123

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # brulee (development version)
 
+* `predict.brulee_chronos()` no longer requires the outcome column in `new_data`. When `new_data` carries predictors only (the tidymodels contract), it is treated as the future covariate window and the stored series is forecast, so chronos models work inside tidymodels workflows and `fit_resamples()` (#123).
+
 * The `brulee_saint()` argument `use_target_token` was renamed to `target_token`.
 
 * `brulee_saint()` and `brulee_auto_int()` now support gradient clipping via the `grad_value_clip` and `grad_norm_clip` arguments (both default to `5`), matching `brulee_mlp()` and `brulee_resnet()`. This prevents the loss from overflowing to `NaN` during training with aggressive learning rates.

--- a/R/chronos2-fit.R
+++ b/R/chronos2-fit.R
@@ -146,14 +146,21 @@
 #' ## What happens at `predict()` time
 #'
 #' By default, [predict.brulee_chronos()] forecasts from the context data that
-#' was supplied at construction. The use of `new_data` should be determined by
-#' how the `brulee_chronos()` call passed the data. For example, if no
-#' covariates were originally given to the model, there is no need to pass in
-#' values when calling `predict()` and so on. Pass `future_df` to supply known
-#' future values of any covariate (e.g., holiday flags, planned promotions).
-#' To forecast a __different__ series with the same schema, pass it as
-#' `new_data`. It will be processed through the same blueprint as the original
-#' context.
+#' was supplied at construction, so `new_data` is optional. How you use
+#' `new_data` depends on whether it includes the outcome column:
+#'
+#'  * __Predictors only__ (no outcome column): `new_data` is treated as the
+#'    known future values of the covariates over the forecast window, and the
+#'    model forecasts the series stored at construction. This is the form used
+#'    by tidymodels workflows and `fit_resamples()`, where `new_data` carries
+#'    predictors only. It is equivalent to passing those columns as `future_df`.
+#'  * __Outcome included__: `new_data` is treated as a __different__ series with
+#'    the same schema to forecast instead of the stored one. It is processed
+#'    through the same blueprint as the original context.
+#'
+#' If no covariates were given to the model, there is no need to pass
+#' `new_data` at all. Pass `future_df` to supply known future values of any
+#' covariate (e.g., holiday flags, planned promotions).
 #'
 #' @param x Depending on the context:
 #'

--- a/R/chronos2-predict.R
+++ b/R/chronos2-predict.R
@@ -2,13 +2,25 @@
 #'
 #' @param object A `brulee_chronos` object returned by [brulee_chronos()].
 #' @param new_data Optional data frame in the same long format as the data
-#'   used to build `object`. It should contain the target and covariate
-#'   columns named in `object`, plus the id and timestamp columns when
-#'   those were supplied at construction. (If the model was built without
-#'   an id column, every row of `new_data` is treated as part of the same
-#'   single series; similarly, if the model was built without a timestamp
-#'   column, row order is used as the time order.) If `NULL` (the
-#'   default), the context stored in `object` is used.
+#'   used to build `object`. The target (outcome) column is optional and
+#'   controls how `new_data` is used:
+#'   \itemize{
+#'     \item If the outcome column is __absent__, `new_data` supplies the
+#'       future covariate values over the forecast window and `object`'s
+#'       stored series is forecast. This is the form used by tidymodels
+#'       workflows and `fit_resamples()`, where `new_data` carries
+#'       predictors only; it is equivalent to passing those columns as
+#'       `future_df` (so the two cannot be combined).
+#'     \item If the outcome column is __present__, `new_data` is treated as a
+#'       different series with the same schema to forecast instead of the
+#'       stored one.
+#'   }
+#'   Include the covariate columns named in `object`, plus the id and
+#'   timestamp columns when those were supplied at construction. (If the
+#'   model was built without an id column, every row of `new_data` is
+#'   treated as part of the same single series; similarly, if the model was
+#'   built without a timestamp column, row order is used as the time order.)
+#'   If `NULL` (the default), the context stored in `object` is used.
 #' @param future_df Optional data frame with future covariate values. Must
 #'   contain the id and timestamp columns (when present in the original
 #'   model) plus any covariate columns to provide for the future window (a
@@ -134,9 +146,37 @@ predict.brulee_chronos <- function(
   timestamp_synthetic <- isTRUE(object$context$timestamp_synthetic)
   has_stored_covariates <- length(covariate_cols) > 0L
 
+  # Does `new_data` carry the outcome column? When it does not (the
+  # tidymodels contract, where `new_data` is predictors only), we forecast
+  # the stored series and use `new_data` as the future covariate window.
+  # When it does, `new_data` is treated as a different series to forecast.
+  # `target_column` holds the stored outcome name (the real column for
+  # formula / recipe models, ".outcome" for the x_y interface).
+  new_data_has_outcome <- !is.null(new_data) &&
+    target_column %in% names(new_data)
+
   # Resolve context: stored or forged from new_data
-  if (is.null(new_data)) {
+  if (is.null(new_data) || !new_data_has_outcome) {
+    # Forecast the series stored at construction.
     ctx <- object$context
+
+    # Predictors-only `new_data` supplies the future covariate values.
+    if (!is.null(new_data) && has_stored_covariates) {
+      if (!is.null(future_df)) {
+        cli::cli_abort(c(
+          "Cannot use both a predictors-only {.arg new_data} and {.arg future_df}.",
+          "i" = "Both supply future covariate values; pass only one."
+        ))
+      }
+      future_df <- chronos2_new_data_as_future(
+        new_data,
+        object,
+        id_column = id_column,
+        timestamp_column = timestamp_column,
+        id_synthetic = id_synthetic,
+        timestamp_synthetic = timestamp_synthetic
+      )
+    }
   } else {
     if (has_stored_covariates) {
       forged <- hardhat::forge(
@@ -355,6 +395,40 @@ chronos2_pull_column <- function(data, column, arg_label) {
     )
   }
   data[[column]]
+}
+
+# Turn predictors-only `new_data` into a `future_df`-shaped frame: the forged
+# covariate columns plus the id / timestamp columns (pulled from recipe roles
+# when available, otherwise by name from `new_data`). The result is consumed
+# by the future-covariate block in `predict.brulee_chronos()`.
+chronos2_new_data_as_future <- function(
+  new_data,
+  object,
+  id_column,
+  timestamp_column,
+  id_synthetic,
+  timestamp_synthetic
+) {
+  forged <- hardhat::forge(new_data, object$blueprint, outcomes = FALSE)
+  roles <- forged$extras$roles
+  future <- as.data.frame(forged$predictors)
+
+  if (!id_synthetic) {
+    future[[id_column]] <- if (!is.null(roles) && !is.null(roles$id)) {
+      roles$id[[1L]]
+    } else {
+      chronos2_pull_column(new_data, id_column, "id_column")
+    }
+  }
+  if (!timestamp_synthetic) {
+    future[[timestamp_column]] <- if (!is.null(roles) && !is.null(roles$time)) {
+      roles$time[[1L]]
+    } else {
+      chronos2_pull_column(new_data, timestamp_column, "timestamp_column")
+    }
+  }
+
+  future
 }
 
 # ─── Internal prediction engine ──────────────────────────────────────────────

--- a/R/chronos2-predict.R
+++ b/R/chronos2-predict.R
@@ -1,36 +1,41 @@
 #' Predict from a `brulee_chronos` model
 #'
 #' @param object A `brulee_chronos` object returned by [brulee_chronos()].
-#' @param new_data Optional data frame in the same long format as the data
-#'   used to build `object`. The target (outcome) column is optional and
-#'   controls how `new_data` is used:
-#'   \itemize{
-#'     \item If the outcome column is __absent__, `new_data` supplies the
-#'       future covariate values over the forecast window and `object`'s
-#'       stored series is forecast. This is the form used by tidymodels
-#'       workflows and `fit_resamples()`, where `new_data` carries
-#'       predictors only; it is equivalent to passing those columns as
-#'       `future_df` (so the two cannot be combined).
-#'     \item If the outcome column is __present__, `new_data` is treated as a
-#'       different series with the same schema to forecast instead of the
-#'       stored one.
-#'   }
-#'   Include the covariate columns named in `object`, plus the id and
-#'   timestamp columns when those were supplied at construction. (If the
-#'   model was built without an id column, every row of `new_data` is
-#'   treated as part of the same single series; similarly, if the model was
-#'   built without a timestamp column, row order is used as the time order.)
-#'   If `NULL` (the default), the context stored in `object` is used.
-#' @param future_df Optional data frame with future covariate values. Must
-#'   contain the id and timestamp columns (when present in the original
-#'   model) plus any covariate columns to provide for the future window (a
-#'   subset of the past covariates). Each series must have exactly
-#'   `prediction_length` rows.
+#' @param new_data Optional data frame of values in the same long format as
+#'   the data used to build `object`. If `NULL` (the default), the series
+#'   stored in `object` is forecast. Whether `new_data` includes the outcome
+#'   column changes how it is used; see Details.
+#' @param future_df Optional data frame of known future covariate values; see
+#'   Details.
 #' @param prediction_length Number of future time steps to forecast. Defaults
 #'   to the value stored in `object`.
 #' @param quantile_levels Numeric vector of quantile levels. Defaults to the
 #'   value stored in `object`.
 #' @param ... Not used.
+#'
+#' @details
+#' By default (`new_data = NULL`), the model forecasts the series stored at
+#' construction. When `new_data` is supplied, how it is used depends on
+#' whether it includes the outcome column:
+#'
+#'  * __Predictors only__ (no outcome column): `new_data` supplies the known
+#'    future covariate values over the forecast window, and the stored series
+#'    is forecast. This is the form used by tidymodels workflows and
+#'    `fit_resamples()`. It is equivalent to passing those columns as
+#'    `future_df`, so the two cannot be combined.
+#'  * __Outcome included__: `new_data` is treated as a different series with
+#'    the same schema to forecast instead of the stored one.
+#'
+#' In either case, include the covariate columns named in `object`, plus the
+#' id and timestamp columns when those were supplied at construction. If the
+#' model was built without an id column, every row is treated as part of one
+#' single series; without a timestamp column, row order is used as the time
+#' order.
+#'
+#' `future_df` must contain the id and timestamp columns (when present in the
+#' original model) plus any covariate columns to supply for the future window
+#' (a subset of the past covariates), with exactly `prediction_length` rows
+#' per series.
 #'
 #' @returns A [tibble][tibble::tibble] with one row per future time step
 #'   per series, in the same order as the rows of `new_data` (or the stored

--- a/man/brulee_chronos.Rd
+++ b/man/brulee_chronos.Rd
@@ -290,14 +290,22 @@ order as its time order. Pre-sort each series before calling
 \subsection{What happens at \code{predict()} time}{
 
 By default, \code{\link[=predict.brulee_chronos]{predict.brulee_chronos()}} forecasts from the context data that
-was supplied at construction. The use of \code{new_data} should be determined by
-how the \code{brulee_chronos()} call passed the data. For example, if no
-covariates were originally given to the model, there is no need to pass in
-values when calling \code{predict()} and so on. Pass \code{future_df} to supply known
-future values of any covariate (e.g., holiday flags, planned promotions).
-To forecast a \strong{different} series with the same schema, pass it as
-\code{new_data}. It will be processed through the same blueprint as the original
-context.
+was supplied at construction, so \code{new_data} is optional. How you use
+\code{new_data} depends on whether it includes the outcome column:
+\itemize{
+\item \strong{Predictors only} (no outcome column): \code{new_data} is treated as the
+known future values of the covariates over the forecast window, and the
+model forecasts the series stored at construction. This is the form used
+by tidymodels workflows and \code{fit_resamples()}, where \code{new_data} carries
+predictors only. It is equivalent to passing those columns as \code{future_df}.
+\item \strong{Outcome included}: \code{new_data} is treated as a \strong{different} series with
+the same schema to forecast instead of the stored one. It is processed
+through the same blueprint as the original context.
+}
+
+If no covariates were given to the model, there is no need to pass
+\code{new_data} at all. Pass \code{future_df} to supply known future values of any
+covariate (e.g., holiday flags, planned promotions).
 }
 }
 \examples{

--- a/man/predict.brulee_chronos.Rd
+++ b/man/predict.brulee_chronos.Rd
@@ -16,32 +16,13 @@
 \arguments{
 \item{object}{A \code{brulee_chronos} object returned by \code{\link[=brulee_chronos]{brulee_chronos()}}.}
 
-\item{new_data}{Optional data frame in the same long format as the data
-used to build \code{object}. The target (outcome) column is optional and
-controls how \code{new_data} is used:
-\itemize{
-\item If the outcome column is \strong{absent}, \code{new_data} supplies the
-future covariate values over the forecast window and \code{object}'s
-stored series is forecast. This is the form used by tidymodels
-workflows and \code{fit_resamples()}, where \code{new_data} carries
-predictors only; it is equivalent to passing those columns as
-\code{future_df} (so the two cannot be combined).
-\item If the outcome column is \strong{present}, \code{new_data} is treated as a
-different series with the same schema to forecast instead of the
-stored one.
-}
-Include the covariate columns named in \code{object}, plus the id and
-timestamp columns when those were supplied at construction. (If the
-model was built without an id column, every row of \code{new_data} is
-treated as part of the same single series; similarly, if the model was
-built without a timestamp column, row order is used as the time order.)
-If \code{NULL} (the default), the context stored in \code{object} is used.}
+\item{new_data}{Optional data frame of values in the same long format as
+the data used to build \code{object}. If \code{NULL} (the default), the series
+stored in \code{object} is forecast. Whether \code{new_data} includes the outcome
+column changes how it is used; see Details.}
 
-\item{future_df}{Optional data frame with future covariate values. Must
-contain the id and timestamp columns (when present in the original
-model) plus any covariate columns to provide for the future window (a
-subset of the past covariates). Each series must have exactly
-\code{prediction_length} rows.}
+\item{future_df}{Optional data frame of known future covariate values; see
+Details.}
 
 \item{prediction_length}{Number of future time steps to forecast. Defaults
 to the value stored in \code{object}.}
@@ -65,6 +46,31 @@ all requested quantile levels into a single column.}
 }
 \description{
 Predict from a \code{brulee_chronos} model
+}
+\details{
+By default (\code{new_data = NULL}), the model forecasts the series stored at
+construction. When \code{new_data} is supplied, how it is used depends on
+whether it includes the outcome column:
+\itemize{
+\item \strong{Predictors only} (no outcome column): \code{new_data} supplies the known
+future covariate values over the forecast window, and the stored series
+is forecast. This is the form used by tidymodels workflows and
+\code{fit_resamples()}. It is equivalent to passing those columns as
+\code{future_df}, so the two cannot be combined.
+\item \strong{Outcome included}: \code{new_data} is treated as a different series with
+the same schema to forecast instead of the stored one.
+}
+
+In either case, include the covariate columns named in \code{object}, plus the
+id and timestamp columns when those were supplied at construction. If the
+model was built without an id column, every row is treated as part of one
+single series; without a timestamp column, row order is used as the time
+order.
+
+\code{future_df} must contain the id and timestamp columns (when present in the
+original model) plus any covariate columns to supply for the future window
+(a subset of the past covariates), with exactly \code{prediction_length} rows
+per series.
 }
 \examples{
 \dontshow{if (!brulee:::is_cran_check()) withAutoprint(\{ # examplesIf}

--- a/man/predict.brulee_chronos.Rd
+++ b/man/predict.brulee_chronos.Rd
@@ -17,13 +17,25 @@
 \item{object}{A \code{brulee_chronos} object returned by \code{\link[=brulee_chronos]{brulee_chronos()}}.}
 
 \item{new_data}{Optional data frame in the same long format as the data
-used to build \code{object}. It should contain the target and covariate
-columns named in \code{object}, plus the id and timestamp columns when
-those were supplied at construction. (If the model was built without
-an id column, every row of \code{new_data} is treated as part of the same
-single series; similarly, if the model was built without a timestamp
-column, row order is used as the time order.) If \code{NULL} (the
-default), the context stored in \code{object} is used.}
+used to build \code{object}. The target (outcome) column is optional and
+controls how \code{new_data} is used:
+\itemize{
+\item If the outcome column is \strong{absent}, \code{new_data} supplies the
+future covariate values over the forecast window and \code{object}'s
+stored series is forecast. This is the form used by tidymodels
+workflows and \code{fit_resamples()}, where \code{new_data} carries
+predictors only; it is equivalent to passing those columns as
+\code{future_df} (so the two cannot be combined).
+\item If the outcome column is \strong{present}, \code{new_data} is treated as a
+different series with the same schema to forecast instead of the
+stored one.
+}
+Include the covariate columns named in \code{object}, plus the id and
+timestamp columns when those were supplied at construction. (If the
+model was built without an id column, every row of \code{new_data} is
+treated as part of the same single series; similarly, if the model was
+built without a timestamp column, row order is used as the time order.)
+If \code{NULL} (the default), the context stored in \code{object} is used.}
 
 \item{future_df}{Optional data frame with future covariate values. Must
 contain the id and timestamp columns (when present in the original

--- a/tests/testthat/_snaps/chronos2-predict.md
+++ b/tests/testthat/_snaps/chronos2-predict.md
@@ -22,6 +22,15 @@
       Error in `chronos2_pull_column()`:
       ! Column "date" (from `timestamp_column`) not found in `new_data`.
 
+# predict errors when predictors-only new_data and future_df are both supplied
+
+    Code
+      predict(mod, new_data = future, future_df = future, prediction_length = 5L)
+    Condition
+      Error in `predict()`:
+      ! Cannot use both a predictors-only `new_data` and `future_df`.
+      i Both supply future covariate values; pass only one.
+
 # future_df missing the id column errors
 
     Code

--- a/tests/testthat/test-chronos2-predict.R
+++ b/tests/testthat/test-chronos2-predict.R
@@ -268,6 +268,159 @@ test_that("predict with new_data on multi-series recipe model has id column", {
   expect_equal(nrow(out), 8L)
 })
 
+# ------------------------------------------------------------------------------
+# predictors-only new_data (tidymodels contract): no outcome column required
+
+test_that("predict with predictors-only new_data forecasts the stored series", {
+  # The issue #123 reprex: a covariate model must predict from `new_data` that
+  # carries predictors only (no outcome), as tidymodels workflows do.
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+
+  mod <- brulee_chronos(
+    ridership ~ Clark_Lake + Austin,
+    data = Chi,
+    id_column = "series_id",
+    timestamp_column = "date",
+    prediction_length = 5L
+  )
+
+  future <- data.frame(
+    series_id = rep("L", 5),
+    date = seq(max(Chi$date) + 1, by = "day", length.out = 5),
+    Clark_Lake = rnorm(5),
+    Austin = rnorm(5)
+  )
+
+  out <- predict(mod, new_data = future)
+  expect_s3_class(out, "tbl_df")
+  expect_named(out, c(".pred", ".pred_quantile"))
+  expect_equal(nrow(out), 5L)
+})
+
+test_that("predict with predictors-only new_data works through a recipe", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("recipes")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+
+  rec <- recipes::recipe(ridership ~ ., data = Chi) |>
+    recipes::update_role(series_id, new_role = "id") |>
+    recipes::update_role(date, new_role = "time")
+  mod <- brulee_chronos(rec, data = Chi, prediction_length = 4L)
+
+  future <- data.frame(
+    series_id = rep("L", 4),
+    date = seq(max(Chi$date) + 1, by = "day", length.out = 4),
+    Clark_Lake = rnorm(4),
+    Austin = rnorm(4)
+  )
+
+  out <- predict(mod, new_data = future)
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 4L)
+})
+
+test_that("predict with predictors-only new_data on a multi-series model", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+  multi <- rbind(
+    transform(Chi, series_id = "A"),
+    transform(Chi, series_id = "B")
+  )
+
+  mod <- brulee_chronos(
+    ridership ~ .,
+    data = multi,
+    id_column = "series_id",
+    timestamp_column = "date",
+    prediction_length = 3L
+  )
+
+  future <- rbind(
+    data.frame(
+      series_id = "A",
+      date = seq(max(Chi$date) + 1, by = "day", length.out = 3),
+      Clark_Lake = rnorm(3),
+      Austin = rnorm(3)
+    ),
+    data.frame(
+      series_id = "B",
+      date = seq(max(Chi$date) + 1, by = "day", length.out = 3),
+      Clark_Lake = rnorm(3),
+      Austin = rnorm(3)
+    )
+  )
+
+  out <- predict(mod, new_data = future)
+  expect_named(out, c("series_id", ".pred", ".pred_quantile"))
+  expect_setequal(out$series_id, c("A", "B"))
+  expect_equal(nrow(out), 6L)
+})
+
+test_that("predict with predictors-only new_data on a no-covariate model uses stored context", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+
+  mod <- brulee_chronos(
+    ridership ~ 1,
+    data = Chi,
+    id_column = "series_id",
+    timestamp_column = "date",
+    prediction_length = 5L
+  )
+
+  # No outcome column, no covariates: falls back to the stored series.
+  new_df <- data.frame(
+    series_id = rep("L", 5),
+    date = seq(max(Chi$date) + 1, by = "day", length.out = 5)
+  )
+
+  out <- predict(mod, new_data = new_df)
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 5L)
+})
+
+test_that("predict errors when predictors-only new_data and future_df are both supplied", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+
+  mod <- brulee_chronos(
+    ridership ~ Clark_Lake + Austin,
+    data = Chi,
+    id_column = "series_id",
+    timestamp_column = "date",
+    prediction_length = 5L
+  )
+
+  future <- data.frame(
+    series_id = rep("L", 5),
+    date = seq(max(Chi$date) + 1, by = "day", length.out = 5),
+    Clark_Lake = rnorm(5),
+    Austin = rnorm(5)
+  )
+
+  expect_snapshot(error = TRUE, {
+    predict(mod, new_data = future, future_df = future, prediction_length = 5L)
+  })
+})
+
+# ------------------------------------------------------------------------------
+
 test_that("predict errors when new_data has non-numeric covariates (no-forge path)", {
   skip_on_cran()
   skip_if_not_installed("hardhat")


### PR DESCRIPTION
This PR fixes #123: `predict.brulee_chronos()` no longer requires the outcome column in `new_data`, so chronos models work through tidymodels workflows and `fit_resamples()`.

The fix makes prediction look at whether `new_data` includes the outcome column and react accordingly. When the outcome is absent, `new_data` is treated as the future covariate window and the model forecasts the series it was trained on — this is the form tidymodels sends, and it reuses the same future-covariate machinery that `future_df` already relied on. When the outcome is present, behavior is unchanged: `new_data` is a different series to forecast, so nothing breaks for anyone already doing that. Passing both a predictors-only `new_data` and `future_df` is ambiguous, so that combination now errors with a clear message.

One detail worth noting: the outcome check keys off the stored target column name rather than the blueprint's outcome type, because for no-covariate and `x_y` models the blueprint reports the generic `.outcome`, which would otherwise misclassify them.