### PR TITLE
rework `predict()` arguments 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,6 +57,13 @@ jobs:
           extra-packages: any::rcmdcheck, local::.
           needs: check
 
+      ## Due to the RSPM setting opemp improperly circa 2026-06-30
+      - name: Install gower from source (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          install.packages("gower", type = "source")
+        shell: Rscript {0}
+
       - name: Install Chronos2 weights
         run: |
           brulee:::chronos2_download()

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * There is now a `type` argument to `predict.brulee_chronos()`: `"all"` returns `.pred` and `.pred_quantile` (unchanged default), `"numeric"` returns only `.pred`, `"quantile"` returns only `.pred_quantile`. The id column is still prepended for multi-series models regardless of type.
 
+* Fixed a bug where torch's L-BFGS optimizer'''s internal convergence flag is NA, throwing an unhelpful error. 
+
 ## Breaking Changes
 
 * `predict()` for `brulee_chronos()` models was reworked. The historical context is always the data supplied to `brulee_chronos()` (the model is pretrained and does no training), so the former `new_data` context-override was removed. The argument previously called `future_df` is now `new_data`: it describes the future window to forecast for and may have at most `prediction_length` rows per series (previously exactly `prediction_length`). When fewer rows are supplied, the forecast is truncated to those rows. `predict()` also gained a `type` argument (`"all"`, `"numeric"`, or `"quantile"`) to select which prediction columns are returned.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 * `brulee_saint()` and `brulee_auto_int()` now support gradient clipping via the `grad_value_clip` and `grad_norm_clip` arguments (both default to `5`), matching `brulee_mlp()` and `brulee_resnet()`. This prevents the loss from overflowing to `NaN` during training with aggressive learning rates.
 
+* There is now a `type` argument to `predict.brulee_chronos()`: `"all"` returns `.pred` and `.pred_quantile` (unchanged default), `"numeric"` returns only `.pred`, `"quantile"` returns only `.pred_quantile`. The id column is still prepended for multi-series models regardless of type.
+
+## Breaking Changes
+
+* `predict()` for `brulee_chronos()` models was reworked. The historical context is always the data supplied to `brulee_chronos()` (the model is pretrained and does no training), so the former `new_data` context-override was removed. The argument previously called `future_df` is now `new_data`: it describes the future window to forecast for and may have at most `prediction_length` rows per series (previously exactly `prediction_length`). When fewer rows are supplied, the forecast is truncated to those rows. `predict()` also gained a `type` argument (`"all"`, `"numeric"`, or `"quantile"`) to select which prediction columns are returned.
+
 # brulee 1.0.0
 
 New models for tabular data:

--- a/R/chronos2-fit.R
+++ b/R/chronos2-fit.R
@@ -145,15 +145,15 @@
 #'
 #' ## What happens at `predict()` time
 #'
-#' By default, [predict.brulee_chronos()] forecasts from the context data that
-#' was supplied at construction. The use of `new_data` should be determined by
-#' how the `brulee_chronos()` call passed the data. For example, if no
-#' covariates were originally given to the model, there is no need to pass in
-#' values when calling `predict()` and so on. Pass `future_df` to supply known
-#' future values of any covariate (e.g., holiday flags, planned promotions).
-#' To forecast a __different__ series with the same schema, pass it as
-#' `new_data`. It will be processed through the same blueprint as the original
-#' context.
+#' The model is pretrained and performs no training, so the historical context
+#' is always the data supplied at construction; [predict.brulee_chronos()]
+#' forecasts forward from that context. By default it returns the full
+#' `prediction_length` horizon. To forecast a specific future window---and to
+#' supply known future values of any covariate (e.g., holiday flags, planned
+#' promotions)---pass that window as `new_data`. Its per-series row count sets
+#' how many future steps are returned (at most `prediction_length`). When the
+#' model has no covariates, `new_data` only needs the id and timestamp columns
+#' that describe the future steps.
 #'
 #' @param x Depending on the context:
 #'

--- a/R/chronos2-predict.R
+++ b/R/chronos2-predict.R
@@ -1,34 +1,40 @@
 #' Predict from a `brulee_chronos` model
 #'
 #' @param object A `brulee_chronos` object returned by [brulee_chronos()].
-#' @param new_data Optional data frame in the same long format as the data
-#'   used to build `object`. It should contain the target and covariate
-#'   columns named in `object`, plus the id and timestamp columns when
-#'   those were supplied at construction. (If the model was built without
-#'   an id column, every row of `new_data` is treated as part of the same
-#'   single series; similarly, if the model was built without a timestamp
-#'   column, row order is used as the time order.) If `NULL` (the
-#'   default), the context stored in `object` is used.
-#' @param future_df Optional data frame with future covariate values. Must
-#'   contain the id and timestamp columns (when present in the original
-#'   model) plus any covariate columns to provide for the future window (a
-#'   subset of the past covariates). Each series must have exactly
-#'   `prediction_length` rows.
+#' @param new_data Optional data frame describing the future window to
+#'   forecast for. It should contain the id and timestamp columns (when those
+#'   were supplied at construction) plus any known future covariate values (a
+#'   subset of the past covariates). The number of rows per series is the
+#'   number of future time steps to return and may be at most
+#'   `prediction_length`; supplying more is an error. When a series has fewer
+#'   rows than `prediction_length`, the missing future covariates are treated
+#'   as unknown and the forecast is truncated to the rows provided. If `NULL`
+#'   (the default), the full `prediction_length` horizon is forecast from the
+#'   context stored in `object`. The model is pretrained, so the historical
+#'   context is always the data passed to [brulee_chronos()] and is never
+#'   overridden here.
+#' @param type A single string for the type of prediction to return. The
+#'   default `"all"` returns both the point forecast (`.pred`) and the quantile
+#'   forecast (`.pred_quantile`). Use `"numeric"` for only `.pred` or
+#'   `"quantile"` for only `.pred_quantile`.
 #' @param prediction_length Number of future time steps to forecast. Defaults
 #'   to the value stored in `object`.
 #' @param quantile_levels Numeric vector of quantile levels. Defaults to the
 #'   value stored in `object`.
 #' @param ... Not used.
 #'
-#' @returns A [tibble][tibble::tibble] with one row per future time step
-#'   per series, in the same order as the rows of `new_data` (or the stored
-#'   context). Columns:
+#' @returns A [tibble][tibble::tibble] with one row per forecast time step
+#'   per series (up to `nrow(new_data)` rows per series, or
+#'   `prediction_length` rows when `new_data` is `NULL`). Columns depend on
+#'   `type`:
 #'   \describe{
 #'     \item{`<id_column>`}{The time series identifier. Omitted when the
 #'       context contains a single series.}
-#'     \item{`.pred`}{Point forecast, i.e. the median of `.pred_quantile`.}
+#'     \item{`.pred`}{Point forecast, i.e. the median of `.pred_quantile`.
+#'       Returned when `type` is `"all"` or `"numeric"`.}
 #'     \item{`.pred_quantile`}{A [hardhat::quantile_pred()] vector packing
-#'       all requested quantile levels into a single column.}
+#'       all requested quantile levels into a single column. Returned when
+#'       `type` is `"all"` or `"quantile"`.}
 #'   }
 #' @examplesIf !brulee:::is_cran_check()
 #' pkgs <- c("recipes", "lubridate", "modeldata", "ggplot2")
@@ -56,7 +62,7 @@
 #'    timestamp_column = c(date),
 #'    prediction_length = 14)
 #'
-#'  pred_1 <- predict(mod_1, test_data)
+#'  pred_1 <- predict(mod_1, new_data = test_data)
 #'  pred_1
 #'
 #'  pred_1 |>
@@ -77,7 +83,7 @@
 #'    timestamp_column = c(date),
 #'    prediction_length = 14)
 #'
-#'  pred_2 <- predict(mod_2, future_df = test_data)
+#'  pred_2 <- predict(mod_2, new_data = test_data)
 #'
 #'  pred_2 |>
 #'   bind_cols(test_data) |>
@@ -96,7 +102,7 @@
 #'
 #'  mod_3 <- brulee_chronos(rec, data = prior_data, prediction_length = 14)
 #'
-#'  pred_3 <- predict(mod_3, future_df = test_data)
+#'  pred_3 <- predict(mod_3, new_data = test_data)
 #'
 #'  pred_3 |>
 #'   bind_cols(test_data) |>
@@ -111,139 +117,49 @@
 predict.brulee_chronos <- function(
   object,
   new_data = NULL,
-  future_df = NULL,
+  type = "all",
   prediction_length = NULL,
   quantile_levels = NULL,
   ...
 ) {
+  type <- rlang::arg_match(type, c("all", "numeric", "quantile"))
   if (is.null(prediction_length)) {
     prediction_length <- object$prediction_length
   }
   if (is.null(quantile_levels)) {
     quantile_levels <- object$quantile_levels
   }
-  if (is.data.frame(new_data) & length(new_data) == 0L) {
+  if (is.data.frame(new_data) && length(new_data) == 0L) {
     new_data <- NULL
   }
 
   id_column <- object$context$id_column
   timestamp_column <- object$context$timestamp_column
-  target_column <- object$context$target_column
-  covariate_cols <- object$context$covariate_cols
   id_synthetic <- isTRUE(object$context$id_synthetic)
   timestamp_synthetic <- isTRUE(object$context$timestamp_synthetic)
-  has_stored_covariates <- length(covariate_cols) > 0L
 
-  # Resolve context: stored or forged from new_data
-  if (is.null(new_data)) {
-    ctx <- object$context
-  } else {
-    if (has_stored_covariates) {
-      forged <- hardhat::forge(
-        new_data,
-        object$blueprint,
-        outcomes = TRUE
-      )
-
-      # Recipe-built models pass id/time through `forged$extras$roles`.
-      # Formula / x_y blueprints don't have that mechanism, so fall back to
-      # pulling those columns by name from `new_data` (or synthesizing,
-      # when the model was built without an id / timestamp column).
-      roles <- forged$extras$roles
-      n_rows <- nrow(new_data)
-
-      if (id_synthetic) {
-        item_id <- rep("default", n_rows)
-      } else if (!is.null(roles) && !is.null(roles$id)) {
-        item_id <- roles$id[[1L]]
-      } else {
-        item_id <- chronos2_pull_column(new_data, id_column, "id_column")
-      }
-
-      if (timestamp_synthetic) {
-        timestamp <- seq_len(n_rows)
-      } else if (!is.null(roles) && !is.null(roles$time)) {
-        timestamp <- roles$time[[1L]]
-      } else {
-        timestamp <- chronos2_pull_column(
-          new_data,
-          timestamp_column,
-          "timestamp_column"
-        )
-      }
-
-      target <- forged$outcomes[[1]]
-      covariates <- as.data.frame(forged$predictors)
-    } else {
-      # No covariates: skip forge entirely. Pull target / id / timestamp by
-      # stored names. (For x_y-built models, target_column == ".outcome", so
-      # the user must include a column with that name.)
-      target <- chronos2_pull_column(new_data, target_column, "target")
-      n_rows <- length(target)
-
-      if (id_synthetic) {
-        item_id <- rep("default", n_rows)
-      } else {
-        item_id <- chronos2_pull_column(new_data, id_column, "id_column")
-      }
-      if (timestamp_synthetic) {
-        timestamp <- seq_len(n_rows)
-      } else {
-        timestamp <- chronos2_pull_column(
-          new_data,
-          timestamp_column,
-          "timestamp_column"
-        )
-      }
-      covariates <- as.data.frame(matrix(
-        NA_real_,
-        nrow = length(target),
-        ncol = 0
-      ))
-    }
-
-    if (!is.numeric(target)) {
-      cli::cli_abort("The target column must be numeric.")
-    }
-    non_numeric <- vapply(
-      covariates,
-      function(col) !is.numeric(col),
-      logical(1)
-    )
-    if (any(non_numeric)) {
-      bad <- names(covariates)[non_numeric]
-      cli::cli_abort(c(
-        "All past covariates must be numeric. Non-numeric column{?s}: {.val {bad}}."
-      ))
-    }
-
-    ctx <- chronos2_split_by_series(
-      target = as.numeric(target),
-      covariates = covariates,
-      item_id = item_id,
-      timestamp = timestamp,
-      id_column = id_column,
-      timestamp_column = timestamp_column,
-      target_column = target_column,
-      id_synthetic = id_synthetic,
-      timestamp_synthetic = timestamp_synthetic
-    )
-  }
-
+  # The context is always the data supplied to `brulee_chronos()`: the model
+  # is pretrained and performs no training, so there is nothing to re-fit at
+  # predict time.
+  ctx <- object$context
   has_covariates <- length(ctx$covariate_cols) > 0
 
-  # Future-covariate handling
+  # `new_data` is the future window: the timestamps (and any known future
+  # covariate values) to forecast for. Its per-series row count is the number
+  # of forecast steps requested, which may be at most `prediction_length`.
+  # When `new_data` is NULL we forecast the full `prediction_length`.
+  requested_lengths <- rep(prediction_length, length(ctx$item_ids))
   future_cov_cols <- character(0)
   future_list <- NULL
-  if (!is.null(future_df)) {
-    if (!id_synthetic && !id_column %in% names(future_df)) {
+  if (!is.null(new_data)) {
+    if (!id_synthetic && !id_column %in% names(new_data)) {
       cli::cli_abort(
-        "Column {.val {id_column}} not found in {.arg future_df}."
+        "Column {.val {id_column}} not found in {.arg new_data}."
       )
     }
-    if (!timestamp_synthetic && !timestamp_column %in% names(future_df)) {
+    if (!timestamp_synthetic && !timestamp_column %in% names(new_data)) {
       cli::cli_abort(
-        "Column {.val {timestamp_column}} not found in {.arg future_df}."
+        "Column {.val {timestamp_column}} not found in {.arg new_data}."
       )
     }
     keep_cols <- c(
@@ -251,21 +167,21 @@ predict.brulee_chronos <- function(
       if (!timestamp_synthetic) timestamp_column,
       ctx$covariate_cols
     )
-    future_df <- future_df[,
-      intersect(names(future_df), keep_cols),
+    new_data <- new_data[,
+      intersect(names(new_data), keep_cols),
       drop = FALSE
     ]
     drop_in_future <- c(
       if (!id_synthetic) id_column,
       if (!timestamp_synthetic) timestamp_column
     )
-    future_cov_cols <- setdiff(names(future_df), drop_in_future)
+    future_cov_cols <- setdiff(names(new_data), drop_in_future)
 
     future_list <- lapply(ctx$item_ids, function(id) {
       sub <- if (id_synthetic) {
-        future_df
+        new_data
       } else {
-        future_df[future_df[[id_column]] == id, , drop = FALSE]
+        new_data[new_data[[id_column]] == id, , drop = FALSE]
       }
       if (timestamp_synthetic) {
         sub
@@ -273,6 +189,18 @@ predict.brulee_chronos <- function(
         sub[order(sub[[timestamp_column]]), , drop = FALSE]
       }
     })
+
+    # The future window sets the per-series forecast horizon. More rows than
+    # `prediction_length` has no meaning; fewer is padded internally and
+    # truncated from the output below.
+    requested_lengths <- vapply(future_list, nrow, integer(1))
+    too_long <- which(requested_lengths > prediction_length)
+    if (length(too_long) > 0L) {
+      i <- too_long[1L]
+      cli::cli_abort(
+        "Series {.val {ctx$item_ids[i]}}: {.arg new_data} has {requested_lengths[i]} rows, more than the prediction length ({prediction_length})."
+      )
+    }
   }
 
   # Per-series target / covariate lists from context. Future timestamps are
@@ -284,13 +212,18 @@ predict.brulee_chronos <- function(
   if (has_covariates) {
     if (length(future_cov_cols) > 0 && !is.null(future_list)) {
       future_cov_list <- lapply(seq_along(ctx$item_ids), function(i) {
-        future_sub <- future_list[[i]]
-        if (nrow(future_sub) != prediction_length) {
-          cli::cli_abort(
-            "Series {.val {ctx$item_ids[i]}}: {.arg future_df} has {nrow(future_sub)} rows, expected {prediction_length}."
+        cov <- future_list[[i]][, future_cov_cols, drop = FALSE]
+        n <- nrow(cov)
+        # Pad short future windows up to `prediction_length` with NA. The model
+        # reads NaN future covariates as "unknown" (mask 0), so the padded tail
+        # does not inform the forecast; it is truncated from the output below.
+        if (n < prediction_length) {
+          cov <- rbind(
+            cov,
+            cov[rep(NA_integer_, prediction_length - n), , drop = FALSE]
           )
         }
-        future_sub[, future_cov_cols, drop = FALSE]
+        cov
       })
     } else {
       future_cov_list <- NULL
@@ -317,27 +250,36 @@ predict.brulee_chronos <- function(
 
   # Build output tibble. Quantile predictions are packed into a single
   # `.pred_quantile` column via hardhat::quantile_pred(); `.pred` is the
-  # median pulled out of that quantile_pred. The id column is omitted when
-  # the context contains a single series; the timestamp column is never
-  # returned.
+  # median pulled out of that quantile_pred. `type` selects which of these
+  # columns to return. The id column is omitted when the context contains a
+  # single series; the timestamp column is never returned. Each series is
+  # truncated to the number of forecast steps requested via `new_data` (the
+  # full `prediction_length` when `new_data` is NULL).
   multiple_series <- length(ctx$item_ids) > 1L
 
   out_rows <- vector("list", length(ctx$item_ids))
   for (i in seq_along(ctx$item_ids)) {
     preds_i <- as.matrix(result$predictions[i, , ])
+    n_i <- requested_lengths[i]
 
     # rows = future timesteps, cols = requested quantile levels
     q_mat <- t(preds_i[quantile_indices, , drop = FALSE])
+    q_mat <- q_mat[seq_len(n_i), , drop = FALSE]
     qp <- hardhat::quantile_pred(q_mat, quantile_levels)
 
-    row_tbl <- tibble::tibble(
-      .pred = as.numeric(stats::median(qp)),
-      .pred_quantile = qp
+    row_tbl <- switch(
+      type,
+      all = tibble::tibble(
+        .pred = as.numeric(stats::median(qp)),
+        .pred_quantile = qp
+      ),
+      numeric = tibble::tibble(.pred = as.numeric(stats::median(qp))),
+      quantile = tibble::tibble(.pred_quantile = qp)
     )
     if (multiple_series) {
       row_tbl <- tibble::add_column(
         row_tbl,
-        !!id_column := rep(ctx$item_ids[i], prediction_length),
+        !!id_column := rep(ctx$item_ids[i], n_i),
         .before = 1L
       )
     }
@@ -346,15 +288,6 @@ predict.brulee_chronos <- function(
   }
 
   dplyr::bind_rows(out_rows)
-}
-
-chronos2_pull_column <- function(data, column, arg_label) {
-  if (!column %in% names(data)) {
-    cli::cli_abort(
-      "Column {.val {column}} (from {.arg {arg_label}}) not found in {.arg new_data}."
-    )
-  }
-  data[[column]]
 }
 
 # ─── Internal prediction engine ──────────────────────────────────────────────
@@ -470,8 +403,8 @@ chronos2_build_inputs <- function(
 
     future_covs <- list()
     if (!is.null(future_covariates[[i]])) {
-      future_df <- as.data.frame(future_covariates[[i]])
-      future_covs <- as.list(future_df)
+      future_cov_df <- as.data.frame(future_covariates[[i]])
+      future_covs <- as.list(future_cov_df)
     }
 
     list(

--- a/R/chronos2-predict.R
+++ b/R/chronos2-predict.R
@@ -177,23 +177,25 @@ predict.brulee_chronos <- function(
     )
     future_cov_cols <- setdiff(names(new_data), drop_in_future)
 
-    future_list <- lapply(ctx$item_ids, function(id) {
-      sub <- if (id_synthetic) {
-        new_data
+    sub_data <- function(id) {
+      if (id_synthetic) {
+        sub <- new_data
       } else {
-        new_data[new_data[[id_column]] == id, , drop = FALSE]
+        sub <- new_data[new_data[[id_column]] == id, , drop = FALSE]
       }
       if (timestamp_synthetic) {
         sub
       } else {
         sub[order(sub[[timestamp_column]]), , drop = FALSE]
       }
-    })
+    }
+
+    future_list <- purrr::map(ctx$item_ids, sub_data)
 
     # The future window sets the per-series forecast horizon. More rows than
     # `prediction_length` has no meaning; fewer is padded internally and
     # truncated from the output below.
-    requested_lengths <- vapply(future_list, nrow, integer(1))
+    requested_lengths <- purrr::map_int(future_list, nrow)
     too_long <- which(requested_lengths > prediction_length)
     if (length(too_long) > 0L) {
       i <- too_long[1L]

--- a/R/training_loop.R
+++ b/R/training_loop.R
@@ -154,6 +154,17 @@ run_training_loop <- function(
     epoch_chr <- format_epoch_labels(1:epochs)
   }
 
+  # Compute the loss for a batch; shared by the optimizer closure and the
+  # divergence check in the training loop below.
+  compute_loss <- function(batch) {
+    pred <- model(batch$x)
+    if (is.null(class_weights)) {
+      loss_fn(pred, batch$y)
+    } else {
+      loss_fn(pred, batch$y, class_weights)
+    }
+  }
+
   # Main training loop
   for (epoch in 1:epochs) {
     # Update learning rate
@@ -168,50 +179,76 @@ run_training_loop <- function(
       optimizer_obj$param_groups[[i]]$lr <- learn_rate
     }
 
-    # Training loop over batches
-    coro::loop(
-      for (batch in dl) {
-        cl <- function() {
-          optimizer_obj$zero_grad()
-          pred <- model(batch$x)
+    # Training loop over batches. The L-BFGS optimizer's internal convergence
+    # check can throw ("missing value where TRUE/FALSE needed") when the loss
+    # diverges to a non-finite value, since its guard only tests `is.na()` and
+    # not `is.finite()` (this has been observed on the MPS backend). When the
+    # step fails on a non-finite loss, treat it as numerical overflow and stop
+    # early; re-raise anything else. The divergence is signaled with a classed
+    # condition so the status can be returned from `tryCatch()`
+    diverged <- tryCatch(
+      {
+        coro::loop(
+          for (batch in dl) {
+            cl <- function() {
+              optimizer_obj$zero_grad()
+              loss <- compute_loss(batch)
+              loss$backward()
 
-          # Call loss function with or without class_weights
-          if (is.null(class_weights)) {
-            loss <- loss_fn(pred, batch$y)
-          } else {
-            loss <- loss_fn(pred, batch$y, class_weights)
-          }
+              # Gradient clipping (MLP only, by default Inf = no clipping)
+              if (is.finite(grad_value_clip)) {
+                try(
+                  torch::nn_utils_clip_grad_value_(
+                    model$parameters,
+                    grad_value_clip
+                  ),
+                  silent = TRUE
+                )
+              }
+              if (is.finite(grad_norm_clip)) {
+                try(
+                  torch::nn_utils_clip_grad_norm_(
+                    model$parameters,
+                    grad_norm_clip
+                  ),
+                  silent = TRUE
+                )
+              }
 
-          loss$backward()
-
-          # Gradient clipping (MLP only, by default Inf = no clipping)
-          if (is.finite(grad_value_clip)) {
-            try(
-              torch::nn_utils_clip_grad_value_(
-                model$parameters,
-                grad_value_clip
-              ),
-              silent = TRUE
+              loss
+            }
+            rlang::try_fetch(
+              optimizer_obj$step(cl),
+              error = function(cnd) {
+                loss_val <- tryCatch(
+                  as.numeric(compute_loss(batch)$item()),
+                  error = function(e) NA_real_
+                )
+                if (is.finite(loss_val)) {
+                  cli::cli_abort(conditionMessage(cnd), parent = cnd)
+                }
+                cli::cli_abort(
+                  "Loss diverged to a non-finite value.",
+                  class = "brulee_diverged"
+                )
+              }
             )
+            if (!is.null(batch_callback)) {
+              batch_callback()
+            }
           }
-          if (is.finite(grad_norm_clip)) {
-            try(
-              torch::nn_utils_clip_grad_norm_(
-                model$parameters,
-                grad_norm_clip
-              ),
-              silent = TRUE
-            )
-          }
-
-          loss
-        }
-        optimizer_obj$step(cl)
-        if (!is.null(batch_callback)) {
-          batch_callback()
-        }
-      }
+        )
+        FALSE
+      },
+      brulee_diverged = function(cnd) TRUE
     )
+
+    if (diverged) {
+      cli::cli_warn(
+        "Early stopping occurred at epoch {epoch} due to numerical overflow of the loss function."
+      )
+      break()
+    }
 
     # Calculate loss on validation or training set
     if (validation > 0) {

--- a/man/brulee_chronos.Rd
+++ b/man/brulee_chronos.Rd
@@ -289,15 +289,15 @@ order as its time order. Pre-sort each series before calling
 
 \subsection{What happens at \code{predict()} time}{
 
-By default, \code{\link[=predict.brulee_chronos]{predict.brulee_chronos()}} forecasts from the context data that
-was supplied at construction. The use of \code{new_data} should be determined by
-how the \code{brulee_chronos()} call passed the data. For example, if no
-covariates were originally given to the model, there is no need to pass in
-values when calling \code{predict()} and so on. Pass \code{future_df} to supply known
-future values of any covariate (e.g., holiday flags, planned promotions).
-To forecast a \strong{different} series with the same schema, pass it as
-\code{new_data}. It will be processed through the same blueprint as the original
-context.
+The model is pretrained and performs no training, so the historical context
+is always the data supplied at construction; \code{\link[=predict.brulee_chronos]{predict.brulee_chronos()}}
+forecasts forward from that context. By default it returns the full
+\code{prediction_length} horizon. To forecast a specific future window---and to
+supply known future values of any covariate (e.g., holiday flags, planned
+promotions)---pass that window as \code{new_data}. Its per-series row count sets
+how many future steps are returned (at most \code{prediction_length}). When the
+model has no covariates, \code{new_data} only needs the id and timestamp columns
+that describe the future steps.
 }
 }
 \examples{

--- a/man/predict.brulee_chronos.Rd
+++ b/man/predict.brulee_chronos.Rd
@@ -7,7 +7,7 @@
 \method{predict}{brulee_chronos}(
   object,
   new_data = NULL,
-  future_df = NULL,
+  type = "all",
   prediction_length = NULL,
   quantile_levels = NULL,
   ...
@@ -16,20 +16,23 @@
 \arguments{
 \item{object}{A \code{brulee_chronos} object returned by \code{\link[=brulee_chronos]{brulee_chronos()}}.}
 
-\item{new_data}{Optional data frame in the same long format as the data
-used to build \code{object}. It should contain the target and covariate
-columns named in \code{object}, plus the id and timestamp columns when
-those were supplied at construction. (If the model was built without
-an id column, every row of \code{new_data} is treated as part of the same
-single series; similarly, if the model was built without a timestamp
-column, row order is used as the time order.) If \code{NULL} (the
-default), the context stored in \code{object} is used.}
+\item{new_data}{Optional data frame describing the future window to
+forecast for. It should contain the id and timestamp columns (when those
+were supplied at construction) plus any known future covariate values (a
+subset of the past covariates). The number of rows per series is the
+number of future time steps to return and may be at most
+\code{prediction_length}; supplying more is an error. When a series has fewer
+rows than \code{prediction_length}, the missing future covariates are treated
+as unknown and the forecast is truncated to the rows provided. If \code{NULL}
+(the default), the full \code{prediction_length} horizon is forecast from the
+context stored in \code{object}. The model is pretrained, so the historical
+context is always the data passed to \code{\link[=brulee_chronos]{brulee_chronos()}} and is never
+overridden here.}
 
-\item{future_df}{Optional data frame with future covariate values. Must
-contain the id and timestamp columns (when present in the original
-model) plus any covariate columns to provide for the future window (a
-subset of the past covariates). Each series must have exactly
-\code{prediction_length} rows.}
+\item{type}{A single string for the type of prediction to return. The
+default \code{"all"} returns both the point forecast (\code{.pred}) and the quantile
+forecast (\code{.pred_quantile}). Use \code{"numeric"} for only \code{.pred} or
+\code{"quantile"} for only \code{.pred_quantile}.}
 
 \item{prediction_length}{Number of future time steps to forecast. Defaults
 to the value stored in \code{object}.}
@@ -40,15 +43,18 @@ value stored in \code{object}.}
 \item{...}{Not used.}
 }
 \value{
-A \link[tibble:tibble]{tibble} with one row per future time step
-per series, in the same order as the rows of \code{new_data} (or the stored
-context). Columns:
+A \link[tibble:tibble]{tibble} with one row per forecast time step
+per series (up to \code{nrow(new_data)} rows per series, or
+\code{prediction_length} rows when \code{new_data} is \code{NULL}). Columns depend on
+\code{type}:
 \describe{
 \item{\verb{<id_column>}}{The time series identifier. Omitted when the
 context contains a single series.}
-\item{\code{.pred}}{Point forecast, i.e. the median of \code{.pred_quantile}.}
+\item{\code{.pred}}{Point forecast, i.e. the median of \code{.pred_quantile}.
+Returned when \code{type} is \code{"all"} or \code{"numeric"}.}
 \item{\code{.pred_quantile}}{A \code{\link[hardhat:quantile_pred]{hardhat::quantile_pred()}} vector packing
-all requested quantile levels into a single column.}
+all requested quantile levels into a single column. Returned when
+\code{type} is \code{"all"} or \code{"quantile"}.}
 }
 }
 \description{
@@ -81,7 +87,7 @@ if (torch::torch_is_installed() & rlang::is_installed(pkgs)) {
    timestamp_column = c(date),
    prediction_length = 14)
 
- pred_1 <- predict(mod_1, test_data)
+ pred_1 <- predict(mod_1, new_data = test_data)
  pred_1
 
  pred_1 |>
@@ -102,7 +108,7 @@ mod_2 <-
    timestamp_column = c(date),
    prediction_length = 14)
 
- pred_2 <- predict(mod_2, future_df = test_data)
+ pred_2 <- predict(mod_2, new_data = test_data)
 
  pred_2 |>
   bind_cols(test_data) |>
@@ -121,7 +127,7 @@ mod_2 <-
 
  mod_3 <- brulee_chronos(rec, data = prior_data, prediction_length = 14)
 
- pred_3 <- predict(mod_3, future_df = test_data)
+ pred_3 <- predict(mod_3, new_data = test_data)
 
  pred_3 |>
   bind_cols(test_data) |>

--- a/tests/testthat/_snaps/autoint.md
+++ b/tests/testthat/_snaps/autoint.md
@@ -88,10 +88,6 @@
       Error in `brulee_auto_int()`:
       ! `grad_value_clip` must be in the range (0, Inf].
 
-# autoint gradient clipping prevents loss overflow
-
-    Early stopping occurred at epoch 1 due to numerical overflow of the loss function.
-
 # autoint default method errors on unsupported types
 
     Code

--- a/tests/testthat/_snaps/chronos2-predict.md
+++ b/tests/testthat/_snaps/chronos2-predict.md
@@ -1,72 +1,32 @@
-# predict with new_data missing the id column errors
+# new_data missing the id column errors
 
     Code
-      predict(mod, new_data = bad, prediction_length = 3L)
-    Condition
-      Error in `chronos2_pull_column()`:
-      ! Column "series_id" (from `id_column`) not found in `new_data`.
-
-# predict with new_data containing a non-numeric target errors
-
-    Code
-      predict(mod, new_data = bad, prediction_length = 3L)
+      predict(mod, new_data = new_df, prediction_length = 3L)
     Condition
       Error in `predict()`:
-      ! The target column must be numeric.
+      ! Column "series_id" not found in `new_data`.
 
-# predict with new_data missing the timestamp column errors
-
-    Code
-      predict(mod, new_data = bad, prediction_length = 3L)
-    Condition
-      Error in `chronos2_pull_column()`:
-      ! Column "date" (from `timestamp_column`) not found in `new_data`.
-
-# future_df missing the id column errors
+# new_data missing the timestamp column errors
 
     Code
-      predict(mod, future_df = future_df, prediction_length = 3L)
+      predict(mod, new_data = new_df, prediction_length = 3L)
     Condition
       Error in `predict()`:
-      ! Column "series_id" not found in `future_df`.
+      ! Column "date" not found in `new_data`.
 
-# future_df missing the timestamp column errors
+# new_data longer than prediction_length errors
 
     Code
-      predict(mod, future_df = future_df, prediction_length = 3L)
+      predict(mod, new_data = new_df, prediction_length = 3L)
     Condition
       Error in `predict()`:
-      ! Column "date" not found in `future_df`.
+      ! Series "L": `new_data` has 5 rows, more than the prediction length (3).
 
-# future_df with wrong row count per series errors
-
-    Code
-      predict(mod, future_df = future_df, prediction_length = 5L)
-    Condition
-      Error in `FUN()`:
-      ! Series "L": `future_df` has 3 rows, expected 5.
-
-# new_data still errors when a required column is missing
+# an unknown type errors
 
     Code
-      predict(mod, new_data = bad, prediction_length = 3L)
-    Condition
-      Error in `hardhat::forge()`:
-      ! The required column "Austin" is missing.
-
-# future_df still errors when the id column is missing
-
-    Code
-      predict(mod, future_df = future_df, prediction_length = 3L)
+      predict(mod, type = "bogus", prediction_length = 3L)
     Condition
       Error in `predict()`:
-      ! Column "series_id" not found in `future_df`.
-
-# chronos2_pull_column errors when the column is missing
-
-    Code
-      brulee:::chronos2_pull_column(data.frame(a = 1:3), "missing_col", "id_column")
-    Condition
-      Error in `brulee:::chronos2_pull_column()`:
-      ! Column "missing_col" (from `id_column`) not found in `new_data`.
+      ! `type` must be one of "all", "numeric", or "quantile", not "bogus".
 

--- a/tests/testthat/test-autoint.R
+++ b/tests/testthat/test-autoint.R
@@ -460,13 +460,16 @@ test_that("autoint gradient clipping prevents loss overflow", {
   )
 
   # Without clipping, the aggressive learning rate overflows the loss
+  # Changed from snapshot beucase GHA and local stop at different epochs with
+  # the same overflow issue
   set.seed(386)
   torch::torch_manual_seed(386)
-  expect_snapshot_warning(
+  expect_warning(
     no_clip <- do.call(
       brulee_auto_int,
       c(auto_int_args, grad_value_clip = Inf, grad_norm_clip = Inf)
-    )
+    ),
+    regexp = "numerical overflow of the loss function"
   )
   expect_true(any(is.nan(no_clip$loss)))
 

--- a/tests/testthat/test-autoint.R
+++ b/tests/testthat/test-autoint.R
@@ -95,6 +95,11 @@ test_that("autoint regression - recipe interface", {
   skip_if_not_installed("torch")
   skip_if_not_installed("recipes")
 
+  # Temp check to remind to see if issues with the gower package have been resolved
+  if (packageVersion("brulee") > "1.0.1.9001") {
+    cli::cli_abort("Recheck RSPM version of gower")
+  }
+
   set.seed(1)
   n <- 80
   df <- data.frame(

--- a/tests/testthat/test-chronos2-fit.R
+++ b/tests/testthat/test-chronos2-fit.R
@@ -649,7 +649,7 @@ test_that("data.frame method synthesizes id and timestamp when omitted", {
 })
 
 # ------------------------------------------------------------------------------
-# predict round-trip with new_data on a model that has no id / timestamp
+# predict with new_data on a model that has no id / timestamp
 
 test_that("predict accepts new_data without id/timestamp when model was synthesized", {
   skip_on_cran()
@@ -661,7 +661,8 @@ test_that("predict accepts new_data without id/timestamp when model was synthesi
 
   mod <- brulee_chronos(ridership ~ Clark_Lake, data = chi_simple)
 
-  out <- predict(mod, new_data = chi_simple, prediction_length = 4L)
+  new_df <- data.frame(Clark_Lake = rnorm(4))
+  out <- predict(mod, new_data = new_df, prediction_length = 4L)
   expect_s3_class(out, "tbl_df")
   expect_named(out, c(".pred", ".pred_quantile"))
   expect_equal(nrow(out), 4L)

--- a/tests/testthat/test-chronos2-predict.R
+++ b/tests/testthat/test-chronos2-predict.R
@@ -1,9 +1,9 @@
 # predict.brulee_chronos() tests.
 #
-# These cover: prediction_length / quantile_levels overrides, new_data
-# round-trips (formula, recipe, x_y), future_df validation, extra columns,
-# and the low-level prediction engine (chronos2_predict_core,
-# chronos2_build_inputs, chronos2_run_with_covariates) with real torch ops.
+# These cover: prediction_length / quantile_levels overrides, the new_data
+# future window (validation, truncation, extra columns), and the low-level
+# prediction engine (chronos2_predict_core, chronos2_build_inputs,
+# chronos2_run_with_covariates) with real torch ops.
 
 # ------------------------------------------------------------------------------
 # prediction_length / quantile_levels overrides
@@ -76,199 +76,9 @@ test_that("predict uses stored context when new_data is NULL", {
 })
 
 # ------------------------------------------------------------------------------
-# new_data round-trips
+# new_data: the future window to forecast for
 
-test_that("predict with new_data forges covariates from a formula model", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("recipes")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-
-  mod <- brulee_chronos(
-    ridership ~ Clark_Lake + Austin,
-    data = Chi,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  out <- predict(mod, new_data = Chi, prediction_length = 3L)
-  expect_s3_class(out, "tbl_df")
-  expect_named(out, c(".pred", ".pred_quantile"))
-  expect_equal(nrow(out), 3L)
-})
-
-test_that("predict with new_data forges through a recipe blueprint", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("recipes")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-
-  rec <- recipes::recipe(ridership ~ ., data = Chi) |>
-    recipes::update_role(series_id, new_role = "id") |>
-    recipes::update_role(date, new_role = "time")
-  mod <- brulee_chronos(rec, data = Chi)
-
-  out <- predict(mod, new_data = Chi, prediction_length = 4L)
-  expect_s3_class(out, "tbl_df")
-  expect_equal(nrow(out), 4L)
-})
-
-test_that("predict with new_data on a multi-series model returns id column", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-  multi_series <- rbind(
-    transform(Chi[, c("series_id", "date", "ridership")], series_id = "A"),
-    transform(Chi[, c("series_id", "date", "ridership")], series_id = "B")
-  )
-
-  mod <- brulee_chronos(
-    ridership ~ .,
-    data = multi_series,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  out <- predict(mod, new_data = multi_series, prediction_length = 3L)
-  expect_named(out, c("series_id", ".pred", ".pred_quantile"))
-  expect_setequal(out$series_id, c("A", "B"))
-})
-
-test_that("predict with new_data missing the id column errors", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-
-  mod <- brulee_chronos(
-    ridership ~ .,
-    data = Chi[, c("series_id", "date", "ridership")],
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  bad <- Chi[, c("date", "ridership")]
-  expect_snapshot(error = TRUE, {
-    predict(mod, new_data = bad, prediction_length = 3L)
-  })
-})
-
-test_that("predict with new_data containing a non-numeric target errors", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-  chi <- Chi[, c("series_id", "date", "ridership")]
-
-  mod <- brulee_chronos(
-    ridership ~ .,
-    data = chi,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  bad <- chi
-  bad$ridership <- as.character(bad$ridership)
-  expect_snapshot(error = TRUE, {
-    predict(mod, new_data = bad, prediction_length = 3L)
-  })
-})
-
-test_that("predict with new_data on no-covariate model pulls target by name", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-  chi <- Chi[, c("series_id", "date", "ridership")]
-
-  mod <- brulee_chronos(
-    ridership ~ .,
-    data = chi,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  out <- predict(mod, new_data = chi, prediction_length = 5L)
-  expect_s3_class(out, "tbl_df")
-  expect_equal(nrow(out), 5L)
-  expect_named(out, c(".pred", ".pred_quantile"))
-})
-
-test_that("predict with new_data missing the timestamp column errors", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("recipes")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-  chi <- Chi[, c("series_id", "date", "ridership")]
-
-  mod <- brulee_chronos(
-    ridership ~ .,
-    data = chi,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  bad <- chi[, c("series_id", "ridership")]
-  expect_snapshot(error = TRUE, {
-    predict(mod, new_data = bad, prediction_length = 3L)
-  })
-})
-
-test_that("predict with new_data on no-covariate x_y model works", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("recipes")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-
-  mod <- brulee_chronos(
-    x = Chi[, character(0), drop = FALSE],
-    y = Chi$ridership
-  )
-
-  new_df <- data.frame(.outcome = Chi$ridership[1:50])
-  out <- predict(mod, new_data = new_df, prediction_length = 3L)
-  expect_s3_class(out, "tbl_df")
-  expect_equal(nrow(out), 3L)
-  expect_named(out, c(".pred", ".pred_quantile"))
-})
-
-test_that("predict with new_data on multi-series recipe model has id column", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("recipes")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-  multi <- rbind(
-    transform(Chi, series_id = "A"),
-    transform(Chi, series_id = "B")
-  )
-
-  rec <- recipes::recipe(ridership ~ ., data = multi) |>
-    recipes::update_role(series_id, new_role = "id") |>
-    recipes::update_role(date, new_role = "time")
-  mod <- brulee_chronos(rec, data = multi)
-
-  out <- predict(mod, new_data = multi, prediction_length = 4L)
-  expect_named(out, c("series_id", ".pred", ".pred_quantile"))
-  expect_setequal(out$series_id, c("A", "B"))
-  expect_equal(nrow(out), 8L)
-})
-
-test_that("predict errors when new_data has non-numeric covariates (no-forge path)", {
+test_that("predict with valid new_data runs", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -282,45 +92,19 @@ test_that("predict errors when new_data has non-numeric covariates (no-forge pat
     timestamp_column = "date"
   )
 
-  bad <- Chi
-  bad$Clark_Lake <- as.character(bad$Clark_Lake)
-
-  expect_error(
-    predict(mod, new_data = bad, prediction_length = 3L),
-    "numeric|convert"
-  )
-})
-
-# ------------------------------------------------------------------------------
-# future_df validation
-
-test_that("predict with valid future_df runs", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-
-  mod <- brulee_chronos(
-    ridership ~ Clark_Lake + Austin,
-    data = Chi,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep("L", 5),
     date = seq(max(Chi$date) + 1, by = "day", length.out = 5),
     Clark_Lake = rnorm(5),
     Austin = rnorm(5)
   )
 
-  out <- predict(mod, future_df = future_df, prediction_length = 5L)
+  out <- predict(mod, new_data = new_df, prediction_length = 5L)
   expect_s3_class(out, "tbl_df")
   expect_equal(nrow(out), 5L)
 })
 
-test_that("future_df missing the id column errors", {
+test_that("new_data missing the id column errors", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -334,17 +118,17 @@ test_that("future_df missing the id column errors", {
     timestamp_column = "date"
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     date = seq(max(Chi$date) + 1, by = "day", length.out = 3),
     Clark_Lake = rnorm(3)
   )
 
   expect_snapshot(error = TRUE, {
-    predict(mod, future_df = future_df, prediction_length = 3L)
+    predict(mod, new_data = new_df, prediction_length = 3L)
   })
 })
 
-test_that("future_df missing the timestamp column errors", {
+test_that("new_data missing the timestamp column errors", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -358,17 +142,17 @@ test_that("future_df missing the timestamp column errors", {
     timestamp_column = "date"
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep("L", 3),
     Clark_Lake = rnorm(3)
   )
 
   expect_snapshot(error = TRUE, {
-    predict(mod, future_df = future_df, prediction_length = 3L)
+    predict(mod, new_data = new_df, prediction_length = 3L)
   })
 })
 
-test_that("future_df with an unknown covariate column silently ignores it", {
+test_that("new_data with an unknown covariate column is silently ignored", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -382,18 +166,18 @@ test_that("future_df with an unknown covariate column silently ignores it", {
     timestamp_column = "date"
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep("L", 3),
     date = seq(max(Chi$date) + 1, by = "day", length.out = 3),
     something_else = rnorm(3)
   )
 
-  out <- predict(mod, future_df = future_df, prediction_length = 3L)
+  out <- predict(mod, new_data = new_df, prediction_length = 3L)
   expect_s3_class(out, "tbl_df")
   expect_equal(nrow(out), 3L)
 })
 
-test_that("future_df works when model has synthesized id and timestamp", {
+test_that("new_data works when model has synthesized id and timestamp", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -405,17 +189,17 @@ test_that("future_df works when model has synthesized id and timestamp", {
     data = Chi[, c("ridership", "Clark_Lake", "Austin")]
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     Clark_Lake = rnorm(5),
     Austin = rnorm(5)
   )
 
-  out <- predict(mod, future_df = future_df, prediction_length = 5L)
+  out <- predict(mod, new_data = new_df, prediction_length = 5L)
   expect_s3_class(out, "tbl_df")
   expect_equal(nrow(out), 5L)
 })
 
-test_that("future_df with subset of covariates provides only those to model", {
+test_that("new_data with a subset of covariates provides only those to model", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -429,18 +213,18 @@ test_that("future_df with subset of covariates provides only those to model", {
     timestamp_column = "date"
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep("L", 4),
     date = seq(max(Chi$date) + 1, by = "day", length.out = 4),
     Clark_Lake = rnorm(4)
   )
 
-  out <- predict(mod, future_df = future_df, prediction_length = 4L)
+  out <- predict(mod, new_data = new_df, prediction_length = 4L)
   expect_s3_class(out, "tbl_df")
   expect_equal(nrow(out), 4L)
 })
 
-test_that("future_df is split by series and sorted by timestamp", {
+test_that("new_data is split by series and sorted by timestamp", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -459,19 +243,19 @@ test_that("future_df is split by series and sorted by timestamp", {
   )
 
   future_dates <- seq(max(Chi$date) + 1, by = "day", length.out = 3)
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep(c("B", "A"), each = 3),
     date = rep(future_dates, 2),
     Clark_Lake = rnorm(6)
   )
 
-  out <- predict(mod, future_df = future_df, prediction_length = 3L)
+  out <- predict(mod, new_data = new_df, prediction_length = 3L)
   expect_named(out, c("series_id", ".pred", ".pred_quantile"))
   expect_setequal(out$series_id, c("A", "B"))
   expect_equal(nrow(out), 6L)
 })
 
-test_that("future_df with wrong row count per series errors", {
+test_that("new_data shorter than prediction_length truncates the forecast", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -485,21 +269,18 @@ test_that("future_df with wrong row count per series errors", {
     timestamp_column = "date"
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep("L", 3),
     date = seq(max(Chi$date) + 1, by = "day", length.out = 3),
     Clark_Lake = rnorm(3)
   )
 
-  expect_snapshot(error = TRUE, {
-    predict(mod, future_df = future_df, prediction_length = 5L)
-  })
+  out <- predict(mod, new_data = new_df, prediction_length = 5L)
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 3L)
 })
 
-# ------------------------------------------------------------------------------
-# extra columns in new_data and future_df are silently ignored
-
-test_that("new_data with extra columns works (formula model with covariates)", {
+test_that("new_data longer than prediction_length errors", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -507,22 +288,58 @@ test_that("new_data with extra columns works (formula model with covariates)", {
   Chi <- chicago_subset()
 
   mod <- brulee_chronos(
-    ridership ~ Clark_Lake + Austin,
+    ridership ~ Clark_Lake,
     data = Chi,
     id_column = "series_id",
     timestamp_column = "date"
   )
 
-  extra <- Chi
-  extra$extra_col <- rnorm(nrow(extra))
-  extra$another_one <- "hello"
+  new_df <- data.frame(
+    series_id = rep("L", 5),
+    date = seq(max(Chi$date) + 1, by = "day", length.out = 5),
+    Clark_Lake = rnorm(5)
+  )
 
-  out <- predict(mod, new_data = extra, prediction_length = 3L)
-  expect_s3_class(out, "tbl_df")
-  expect_equal(nrow(out), 3L)
+  expect_snapshot(error = TRUE, {
+    predict(mod, new_data = new_df, prediction_length = 3L)
+  })
 })
 
-test_that("new_data with extra columns works (no-covariate model)", {
+test_that("new_data truncates each series to its own row count", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+  multi <- rbind(
+    transform(Chi, series_id = "A"),
+    transform(Chi, series_id = "B")
+  )
+
+  mod <- brulee_chronos(
+    ridership ~ Clark_Lake,
+    data = multi,
+    id_column = "series_id",
+    timestamp_column = "date"
+  )
+
+  future_dates <- seq(max(Chi$date) + 1, by = "day", length.out = 4)
+  new_df <- data.frame(
+    series_id = c(rep("A", 2), rep("B", 4)),
+    date = c(future_dates[1:2], future_dates[1:4]),
+    Clark_Lake = rnorm(6)
+  )
+
+  out <- predict(mod, new_data = new_df, prediction_length = 5L)
+  expect_equal(nrow(out), 6L)
+  expect_equal(sum(out$series_id == "A"), 2L)
+  expect_equal(sum(out$series_id == "B"), 4L)
+})
+
+# ------------------------------------------------------------------------------
+# type argument
+
+test_that("type = 'all' (default) returns both prediction columns", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -537,16 +354,99 @@ test_that("new_data with extra columns works (no-covariate model)", {
     timestamp_column = "date"
   )
 
-  extra <- chi
-  extra$extra_col <- rnorm(nrow(extra))
-  extra$another_one <- "hello"
-
-  out <- predict(mod, new_data = extra, prediction_length = 3L)
-  expect_s3_class(out, "tbl_df")
-  expect_equal(nrow(out), 3L)
+  out <- predict(mod, prediction_length = 4L)
+  expect_named(out, c(".pred", ".pred_quantile"))
+  expect_equal(nrow(out), 4L)
 })
 
-test_that("future_df with extra columns silently ignores them", {
+test_that("type = 'numeric' returns only .pred", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+  chi <- Chi[, c("series_id", "date", "ridership")]
+
+  mod <- brulee_chronos(
+    ridership ~ .,
+    data = chi,
+    id_column = "series_id",
+    timestamp_column = "date"
+  )
+
+  out <- predict(mod, type = "numeric", prediction_length = 4L)
+  expect_named(out, ".pred")
+  expect_type(out$.pred, "double")
+  expect_equal(nrow(out), 4L)
+})
+
+test_that("type = 'quantile' returns only .pred_quantile", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+  chi <- Chi[, c("series_id", "date", "ridership")]
+
+  mod <- brulee_chronos(
+    ridership ~ .,
+    data = chi,
+    id_column = "series_id",
+    timestamp_column = "date"
+  )
+
+  out <- predict(mod, type = "quantile", prediction_length = 4L)
+  expect_named(out, ".pred_quantile")
+  expect_equal(nrow(out), 4L)
+})
+
+test_that("type keeps the id column for multi-series models", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+  multi <- rbind(
+    transform(Chi[, c("series_id", "date", "ridership")], series_id = "A"),
+    transform(Chi[, c("series_id", "date", "ridership")], series_id = "B")
+  )
+
+  mod <- brulee_chronos(
+    ridership ~ .,
+    data = multi,
+    id_column = "series_id",
+    timestamp_column = "date"
+  )
+
+  out <- predict(mod, type = "numeric", prediction_length = 3L)
+  expect_named(out, c("series_id", ".pred"))
+  expect_setequal(out$series_id, c("A", "B"))
+})
+
+test_that("an unknown type errors", {
+  skip_on_cran()
+  skip_if_not_installed("hardhat")
+  skip_if_not_installed("modeldata")
+  stub_chronos_loaders(also_mock_predict_core = TRUE)
+  Chi <- chicago_subset()
+  chi <- Chi[, c("series_id", "date", "ridership")]
+
+  mod <- brulee_chronos(
+    ridership ~ .,
+    data = chi,
+    id_column = "series_id",
+    timestamp_column = "date"
+  )
+
+  expect_snapshot(error = TRUE, {
+    predict(mod, type = "bogus", prediction_length = 3L)
+  })
+})
+
+# ------------------------------------------------------------------------------
+# extra columns in new_data are silently ignored
+
+test_that("new_data with extra columns is silently ignored (covariate model)", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
@@ -560,7 +460,7 @@ test_that("future_df with extra columns silently ignores them", {
     timestamp_column = "date"
   )
 
-  future_df <- data.frame(
+  new_df <- data.frame(
     series_id = rep("L", 5),
     date = seq(max(Chi$date) + 1, by = "day", length.out = 5),
     Clark_Lake = rnorm(5),
@@ -569,82 +469,36 @@ test_that("future_df with extra columns silently ignores them", {
     unrelated = letters[1:5]
   )
 
-  out <- predict(mod, future_df = future_df, prediction_length = 5L)
+  out <- predict(mod, new_data = new_df, prediction_length = 5L)
   expect_s3_class(out, "tbl_df")
   expect_equal(nrow(out), 5L)
 })
 
-test_that("new_data still errors when a required column is missing", {
+test_that("new_data with extra columns is silently ignored (no-covariate model)", {
   skip_on_cran()
   skip_if_not_installed("hardhat")
   skip_if_not_installed("modeldata")
   stub_chronos_loaders(also_mock_predict_core = TRUE)
   Chi <- chicago_subset()
+  chi <- Chi[, c("series_id", "date", "ridership")]
 
   mod <- brulee_chronos(
-    ridership ~ Clark_Lake + Austin,
-    data = Chi,
+    ridership ~ .,
+    data = chi,
     id_column = "series_id",
     timestamp_column = "date"
   )
 
-  bad <- Chi[, c("series_id", "date", "ridership", "Clark_Lake")]
-  expect_snapshot(
-    error = TRUE,
-    predict(mod, new_data = bad, prediction_length = 3L)
-  )
-})
-
-test_that("future_df still errors when the id column is missing", {
-  skip_on_cran()
-  skip_if_not_installed("hardhat")
-  skip_if_not_installed("modeldata")
-  stub_chronos_loaders(also_mock_predict_core = TRUE)
-  Chi <- chicago_subset()
-
-  mod <- brulee_chronos(
-    ridership ~ Clark_Lake,
-    data = Chi,
-    id_column = "series_id",
-    timestamp_column = "date"
-  )
-
-  future_df <- data.frame(
+  new_df <- data.frame(
+    series_id = rep("L", 3),
     date = seq(max(Chi$date) + 1, by = "day", length.out = 3),
-    Clark_Lake = rnorm(3),
-    extra_col = rnorm(3)
+    extra_col = rnorm(3),
+    unrelated = letters[1:3]
   )
 
-  expect_snapshot(
-    error = TRUE,
-    predict(mod, future_df = future_df, prediction_length = 3L)
-  )
-})
-
-# ------------------------------------------------------------------------------
-# chronos2_pull_column helper
-
-test_that("chronos2_pull_column errors when the column is missing", {
-  skip_on_cran()
-  skip_if_not(torch::torch_is_installed())
-  expect_snapshot(error = TRUE, {
-    brulee:::chronos2_pull_column(
-      data.frame(a = 1:3),
-      "missing_col",
-      "id_column"
-    )
-  })
-})
-
-test_that("chronos2_pull_column returns the column value when present", {
-  skip_on_cran()
-  skip_if_not(torch::torch_is_installed())
-  res <- brulee:::chronos2_pull_column(
-    data.frame(a = 1:3, b = letters[1:3]),
-    "b",
-    "x"
-  )
-  expect_equal(res, letters[1:3])
+  out <- predict(mod, new_data = new_df, prediction_length = 3L)
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 3L)
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Previously: 

* The model always produces `prediction_length` forecast steps per series. Output currently has exactly `prediction_length` rows per series.
* `future_df` = the future covariate window (currently must have exactly `prediction_length` rows per series — test at test-chronos2-predict.R:474 asserts an error otherwise).
* `new_data` = the historical context fed to the model as the series' past; its target column becomes the context. It can legitimately be long (lots of history → forecast 14 steps).

This PR changes the arguments: 

 - The process used for `new_data` has been removed since it only resets the context of the model (on the fly).
 - `future_df` is now named `new_data`. The number of rows can be anything less than the `prediction_length`.
 - A `type` argument is added and keeps the same default two columns. 