### PR TITLE
changes numerical overflow issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 * `brulee_saint()` and `brulee_auto_int()` now support gradient clipping via the `grad_value_clip` and `grad_norm_clip` arguments (both default to `5`), matching `brulee_mlp()` and `brulee_resnet()`. This prevents the loss from overflowing to `NaN` during training with aggressive learning rates.
 
+* All estimated models now include epoch zero (the randomly initialized parameters, before any training) as the first element of `loss` and `estimates`, matching the neural-network models. These vectors are now length `epochs + 1`, `epoch = 0` is a valid argument to `predict()` and `coef()`, and the entry for `best_epoch` is at position `best_epoch + 1`. Predictions and coefficients for a given (positive) epoch are unchanged. Note: objects serialized by earlier versions of these three functions predict off by one epoch under the new indexing, so refit any stored models.
+  * The `print()` methods now report the loss from the best epoch. Previously the displayed loss was taken one epoch too early (it ignored the prepended epoch-zero entry in `loss`).
+
+* `brulee_tab_icl()` makes the open-source foundational model TabICL available. On first use, there is a substantial download (~ 400MB) for the model weights that is cached locally. 
+
 # brulee 1.0.0
 
 New models for tabular data:

--- a/R/0_utils.R
+++ b/R/0_utils.R
@@ -123,7 +123,9 @@ brulee_print <- function(x, ...) {
 
   if (!is.null(x$loss)) {
     it <- x$best_epoch
-    loss_val <- signif(x$loss[it], 3)
+    # `loss` includes epoch zero at position 1, so the best epoch's loss is at
+    # `it + 1` (matching the predict()/coef() indexing).
+    loss_val <- signif(x$loss[it + 1], 3)
     epoch_str <- cli::pluralize("{it} epoch{?s}")
 
     if (x$parameters$validation > 0) {

--- a/R/autoint-fit.R
+++ b/R/autoint-fit.R
@@ -136,10 +136,15 @@
 #' A `brulee_auto_int` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
 #'  * `loss`: A vector of loss values (MSE for regression, negative log-
-#'            likelihood for classification) at each epoch.
+#'            likelihood for classification) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions and feature metadata.
 #'  * `top_interactions`: A tibble containing the top 10 two-way feature
 #'                        interactions.
@@ -1392,6 +1397,12 @@ run_auto_int_training_loop <- function(
     loss_curr <- loss$item()
     loss_vec[epoch] <- loss_curr
 
+    # Save parameters for this epoch before any early-stopping check so the
+    # returned loss curve (including a terminal NaN from numerical overflow)
+    # stays aligned with `param_per_epoch`.
+    param_per_epoch[[epoch]] <-
+      lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
+
     if (is.nan(loss_curr)) {
       cli::cli_warn(
         "Early stopping occurred at epoch {epoch} due to numerical overflow of the loss function."
@@ -1408,9 +1419,6 @@ run_auto_int_training_loop <- function(
     }
 
     loss_prev <- loss_curr
-
-    param_per_epoch[[epoch]] <-
-      lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
 
     if (verbose) {
       cli::cli_inform(
@@ -1732,7 +1740,9 @@ print.brulee_auto_int <- function(x, ...) {
 
   if (!is.null(x$loss)) {
     it <- x$best_epoch
-    loss_val <- signif(x$loss[it], 3)
+    # `loss` includes epoch zero at position 1, so the best epoch's loss is at
+    # `it + 1` (matching the predict()/coef() indexing).
+    loss_val <- signif(x$loss[it + 1], 3)
     epoch_str <- cli::pluralize("{it} epoch{?s}")
 
     if (x$parameters$validation > 0) {

--- a/R/coef.R
+++ b/R/coef.R
@@ -4,7 +4,10 @@ brulee_coefs <- function(object, epoch = NULL, ...) {
     cli::cli_abort("{.arg epoch} should be a single integer.", call = call)
   }
 
-  max_epochs <- length(object$estimates)
+  # All models prepend the initial pre-training parameters as the first element
+  # of `estimates` (epoch zero), so an iteration number is one less than its
+  # position in the list. This offset mirrors the predict() methods.
+  max_epochs <- length(object$estimates) - 1L
 
   if (is.null(epoch)) {
     epoch <- object$best_epoch
@@ -17,7 +20,7 @@ brulee_coefs <- function(object, epoch = NULL, ...) {
       epoch <- max_epochs
     }
   }
-  object$estimates[[epoch]]
+  object$estimates[[epoch + 1L]]
 }
 
 

--- a/R/linear_reg-fit.R
+++ b/R/linear_reg-fit.R
@@ -64,9 +64,14 @@
 #' A `brulee_linear_reg` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
-#'  * `loss`: A vector of loss values (MSE) at each epoch.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
+#'  * `loss`: A vector of loss values (MSE) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions.
 #'  * `y_stats`: A list of summary statistics for numeric outcomes.
 #'  * `parameters`: A list of some tuning parameter values.
@@ -563,6 +568,16 @@ linear_reg_fit_imp <-
 
       ## -------------------------------------------------------------------------
 
+      # Record the randomly initialized model as epoch zero before training
+      init_epoch <- initial_epoch_record(
+        model,
+        dl,
+        dl_val,
+        loss_fn,
+        validation,
+        class_weights = NULL
+      )
+
       # Run training loop
       training_result <- run_training_loop(
         model = model,
@@ -582,7 +597,8 @@ linear_reg_fit_imp <-
 
       list(
         model = model,
-        training_result = training_result
+        training_result = training_result,
+        init_epoch = init_epoch
       )
     })
 
@@ -590,8 +606,14 @@ linear_reg_fit_imp <-
 
     list(
       model_obj = model_to_raw(training_output$model),
-      estimates = training_output$training_result$param_per_epoch,
-      loss = training_output$training_result$loss_vec,
+      estimates = c(
+        list(training_output$init_epoch$params),
+        training_output$training_result$param_per_epoch
+      ),
+      loss = c(
+        training_output$init_epoch$loss,
+        training_output$training_result$loss_vec
+      ),
       best_epoch = training_output$training_result$best_epoch,
       dims = list(p = p, n = n, h = 0, y = y_dim, features = colnames(x)),
       y_stats = y_stats,

--- a/R/linear_reg-predict.R
+++ b/R/linear_reg-predict.R
@@ -100,7 +100,7 @@ predict_brulee_linear_reg_raw <- function(model, predictors, epoch) {
   # convert from raw format
   module <- revive_model(model$model_obj, device)
   # get current model parameters
-  estimates <- model$estimates[[epoch]]
+  estimates <- model$estimates[[epoch + 1]]
   # convert to torch representation on correct device
   estimates <- lapply(estimates, float_32, device = device)
   # stuff back into the model

--- a/R/logistic_reg-fit.R
+++ b/R/logistic_reg-fit.R
@@ -62,10 +62,15 @@
 #' A `brulee_logistic_reg` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
 #'  * `loss`: A vector of loss values (MSE for regression, negative log-
-#'            likelihood for classification) at each epoch.
+#'            likelihood for classification) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions.
 #'  * `parameters`: A list of some tuning parameter values.
 #'  * `blueprint`: The `hardhat` blueprint data.
@@ -564,6 +569,16 @@ logistic_reg_fit_imp <-
 
       ## -------------------------------------------------------------------------
 
+      # Record the randomly initialized model as epoch zero before training
+      init_epoch <- initial_epoch_record(
+        model,
+        dl,
+        dl_val,
+        loss_fn,
+        validation,
+        class_weights = class_weights
+      )
+
       # Run training loop
       training_result <- run_training_loop(
         model = model,
@@ -583,7 +598,8 @@ logistic_reg_fit_imp <-
 
       list(
         model = model,
-        training_result = training_result
+        training_result = training_result,
+        init_epoch = init_epoch
       )
     })
 
@@ -596,8 +612,14 @@ logistic_reg_fit_imp <-
 
     list(
       model_obj = model_to_raw(training_output$model),
-      estimates = training_output$training_result$param_per_epoch,
-      loss = training_output$training_result$loss_vec,
+      estimates = c(
+        list(training_output$init_epoch$params),
+        training_output$training_result$param_per_epoch
+      ),
+      loss = c(
+        training_output$init_epoch$loss,
+        training_output$training_result$loss_vec
+      ),
       best_epoch = training_output$training_result$best_epoch,
       dims = list(
         p = p,

--- a/R/logistic_reg-predict.R
+++ b/R/logistic_reg-predict.R
@@ -112,7 +112,7 @@ predict_brulee_logistic_reg_raw <- function(model, predictors, epoch) {
   # convert from raw format
   module <- revive_model(model$model_obj, device)
   # get current model parameters
-  estimates <- model$estimates[[epoch]]
+  estimates <- model$estimates[[epoch + 1]]
   # convert to torch representation on correct device
   estimates <- lapply(estimates, float_32, device = device)
   # stuff back into the model

--- a/R/mlp-fit.R
+++ b/R/mlp-fit.R
@@ -140,10 +140,15 @@
 #' A `brulee_mlp` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
 #'  * `loss`: A vector of loss values (MSE for regression, negative log-
-#'            likelihood for classification) at each epoch.
+#'            likelihood for classification) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions.
 #'  * `y_stats`: A list of summary statistics for numeric outcomes.
 #'  * `parameters`: A list of some tuning parameter values.

--- a/R/multinomial_reg-fit.R
+++ b/R/multinomial_reg-fit.R
@@ -61,10 +61,15 @@
 #' A `brulee_multinomial_reg` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
 #'  * `loss`: A vector of loss values (MSE for regression, negative log-
-#'            likelihood for classification) at each epoch.
+#'            likelihood for classification) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions.
 #'  * `parameters`: A list of some tuning parameter values.
 #'  * `blueprint`: The `hardhat` blueprint data.
@@ -537,6 +542,16 @@ multinomial_reg_fit_imp <-
 
       ## -------------------------------------------------------------------------
 
+      # Record the randomly initialized model as epoch zero before training
+      init_epoch <- initial_epoch_record(
+        model,
+        dl,
+        dl_val,
+        loss_fn,
+        validation,
+        class_weights = class_weights
+      )
+
       # Run training loop
       training_result <- run_training_loop(
         model = model,
@@ -556,7 +571,8 @@ multinomial_reg_fit_imp <-
 
       list(
         model = model,
-        training_result = training_result
+        training_result = training_result,
+        init_epoch = init_epoch
       )
     })
 
@@ -569,8 +585,14 @@ multinomial_reg_fit_imp <-
 
     list(
       model_obj = model_to_raw(training_output$model),
-      estimates = training_output$training_result$param_per_epoch,
-      loss = training_output$training_result$loss_vec,
+      estimates = c(
+        list(training_output$init_epoch$params),
+        training_output$training_result$param_per_epoch
+      ),
+      loss = c(
+        training_output$init_epoch$loss,
+        training_output$training_result$loss_vec
+      ),
       best_epoch = training_output$training_result$best_epoch,
       dims = list(
         p = p,

--- a/R/multinomial_reg-predict.R
+++ b/R/multinomial_reg-predict.R
@@ -108,7 +108,7 @@ predict_brulee_multinomial_reg_raw <- function(model, predictors, epoch) {
   # convert from raw format
   module <- revive_model(model$model_obj, device)
   # get current model parameters
-  estimates <- model$estimates[[epoch]]
+  estimates <- model$estimates[[epoch + 1]]
   # convert to torch representation on correct device
   estimates <- lapply(estimates, float_32, device = device)
   # stuff back into the model

--- a/R/resnet-fit.R
+++ b/R/resnet-fit.R
@@ -111,10 +111,15 @@
 #' A `brulee_resnet` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
 #'  * `loss`: A vector of loss values (MSE for regression, negative log-
-#'            likelihood for classification) at each epoch.
+#'            likelihood for classification) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions.
 #'  * `y_stats`: A list of summary statistics for numeric outcomes.
 #'  * `parameters`: A list of some tuning parameter values.

--- a/R/rln-fit.R
+++ b/R/rln-fit.R
@@ -86,9 +86,14 @@
 #'
 #' A `brulee_rln` object with elements:
 #'  * `model_obj`: a serialized raw vector for the torch module.
-#'  * `estimates`: a list of model parameter matrices per epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
-#'  * `loss`: a numeric vector of loss values (scaled MSE) at each epoch.
+#'  * `estimates`: a list of model parameter matrices per epoch. The first
+#'                 element is epoch zero (the randomly initialized parameters
+#'                 before training), so the list has `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
+#'  * `loss`: a numeric vector of loss values (scaled MSE) at each epoch,
+#'            starting with epoch zero.
 #'  * `dims`: a list of data dimensions.
 #'  * `y_stats`: a list of mean and standard deviation for the outcome.
 #'  * `parameters`: a list of tuning parameter values.
@@ -853,7 +858,9 @@ print.brulee_rln <- function(x, ...) {
 
   if (!is.null(x$loss)) {
     it <- x$best_epoch
-    loss_val <- signif(x$loss[it], 3)
+    # `loss` includes epoch zero at position 1, so the best epoch's loss is at
+    # `it + 1` (matching the predict()/coef() indexing).
+    loss_val <- signif(x$loss[it + 1], 3)
     epoch_str <- cli::pluralize("{it} epoch{?s}")
     if (x$parameters$validation > 0) {
       res_list <- c(

--- a/R/saint-fit.R
+++ b/R/saint-fit.R
@@ -171,11 +171,16 @@
 #' A `brulee_saint` object with elements:
 #'  * `models_obj`: a serialized raw vector for the torch module.
 #'  * `estimates`: a list of matrices with the model parameter estimates per
-#'                 epoch.
-#'  * `best_epoch`: an integer for the epoch with the smallest loss.
+#'                 epoch. The first element is epoch zero (the randomly
+#'                 initialized parameters before training), so the list has
+#'                 `epochs + 1` elements.
+#'  * `best_epoch`: an integer for the epoch with the smallest loss. Since
+#'                  `estimates` and `loss` include epoch zero, this epoch's
+#'                  values are at position `best_epoch + 1` in those objects.
 #'
 #'  * `loss`: A vector of loss values (MSE for regression, negative log-
-#'            likelihood for classification) at each epoch.
+#'            likelihood for classification) at each epoch, starting with
+#'            epoch zero.
 #'  * `dim`: A list of data dimensions and feature metadata.
 #'  * `y_stats`: A list of summary statistics for numeric outcomes.
 #'  * `parameters`: A list of some tuning parameter values.
@@ -1290,6 +1295,12 @@ run_saint_training_loop <- function(
     loss_curr <- loss$item()
     loss_vec[epoch] <- loss_curr
 
+    # Save parameters for this epoch before any early-stopping check so the
+    # returned loss curve (including a terminal NaN from numerical overflow)
+    # stays aligned with `param_per_epoch`.
+    param_per_epoch[[epoch]] <-
+      lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
+
     if (is.nan(loss_curr)) {
       cli::cli_warn(
         "Early stopping occurred at epoch {epoch} due to numerical overflow of the loss function."
@@ -1306,9 +1317,6 @@ run_saint_training_loop <- function(
     }
 
     loss_prev <- loss_curr
-
-    param_per_epoch[[epoch]] <-
-      lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
 
     if (verbose) {
       cli::cli_inform(
@@ -1787,7 +1795,9 @@ print.brulee_saint <- function(x, ...) {
 
   if (!is.null(x$loss)) {
     it <- x$best_epoch
-    loss_val <- signif(x$loss[it], 3)
+    # `loss` includes epoch zero at position 1, so the best epoch's loss is at
+    # `it + 1` (matching the predict()/coef() indexing).
+    loss_val <- signif(x$loss[it + 1], 3)
     epoch_str <- cli::pluralize("{it} epoch{?s}")
 
     if (x$parameters$validation > 0) {

--- a/R/training_loop.R
+++ b/R/training_loop.R
@@ -234,6 +234,12 @@ run_training_loop <- function(
     loss_curr <- loss$item()
     loss_vec[epoch] <- loss_curr
 
+    # Save parameters for this epoch before any early-stopping check so the
+    # returned loss curve (including a terminal NaN from numerical overflow)
+    # stays aligned with `param_per_epoch`.
+    param_per_epoch[[epoch]] <-
+      lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
+
     # Check for NaN
     if (is.nan(loss_curr)) {
       cli::cli_warn(
@@ -255,10 +261,6 @@ run_training_loop <- function(
 
     loss_prev <- loss_curr
 
-    # Save parameters for this epoch
-    param_per_epoch[[epoch]] <-
-      lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
-
     # Verbose output
     if (verbose) {
       cli::cli_inform(
@@ -277,5 +279,38 @@ run_training_loop <- function(
     param_per_epoch = param_per_epoch,
     loss_vec = loss_vec[1:length(param_per_epoch)],
     best_epoch = best_epoch
+  )
+}
+
+# Record the "iteration zero" state: the loss and parameters of the randomly
+# initialized model, before any training step. All models prepend this to
+# `loss`/`estimates` so that index 1 corresponds to epoch zero and the best
+# epoch's entry is at position `best_epoch + 1`.
+#' @noRd
+initial_epoch_record <- function(
+  model,
+  dl,
+  dl_val,
+  loss_fn,
+  validation,
+  class_weights = NULL
+) {
+  if (validation > 0) {
+    pred <- model(dl_val$dataset$tensors$x)
+    y <- dl_val$dataset$tensors$y
+  } else {
+    pred <- model(dl$dataset$tensors$x)
+    y <- dl$dataset$tensors$y
+  }
+
+  if (is.null(class_weights)) {
+    loss <- loss_fn(pred, y)
+  } else {
+    loss <- loss_fn(pred, y, class_weights)
+  }
+
+  list(
+    loss = loss$item(),
+    params = lapply(model$state_dict(), function(x) torch::as_array(x$cpu()))
   )
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -55,6 +55,7 @@ Shchur
 Shi
 Somepalli
 Springer
+TabICL
 Xiao
 Xu
 Zeiler

--- a/man/brulee_auto_int.Rd
+++ b/man/brulee_auto_int.Rd
@@ -269,10 +269,15 @@ A \code{brulee_auto_int} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
 \item \code{loss}: A vector of loss values (MSE for regression, negative log-
-likelihood for classification) at each epoch.
+likelihood for classification) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions and feature metadata.
 \item \code{top_interactions}: A tibble containing the top 10 two-way feature
 interactions.

--- a/man/brulee_linear_reg.Rd
+++ b/man/brulee_linear_reg.Rd
@@ -154,9 +154,14 @@ A \code{brulee_linear_reg} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
-\item \code{loss}: A vector of loss values (MSE) at each epoch.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
+\item \code{loss}: A vector of loss values (MSE) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions.
 \item \code{y_stats}: A list of summary statistics for numeric outcomes.
 \item \code{parameters}: A list of some tuning parameter values.

--- a/man/brulee_logistic_reg.Rd
+++ b/man/brulee_logistic_reg.Rd
@@ -169,10 +169,15 @@ A \code{brulee_logistic_reg} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
 \item \code{loss}: A vector of loss values (MSE for regression, negative log-
-likelihood for classification) at each epoch.
+likelihood for classification) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions.
 \item \code{parameters}: A list of some tuning parameter values.
 \item \code{blueprint}: The \code{hardhat} blueprint data.

--- a/man/brulee_mlp.Rd
+++ b/man/brulee_mlp.Rd
@@ -333,10 +333,15 @@ A \code{brulee_mlp} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
 \item \code{loss}: A vector of loss values (MSE for regression, negative log-
-likelihood for classification) at each epoch.
+likelihood for classification) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions.
 \item \code{y_stats}: A list of summary statistics for numeric outcomes.
 \item \code{parameters}: A list of some tuning parameter values.

--- a/man/brulee_multinomial_reg.Rd
+++ b/man/brulee_multinomial_reg.Rd
@@ -169,10 +169,15 @@ A \code{brulee_multinomial_reg} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
 \item \code{loss}: A vector of loss values (MSE for regression, negative log-
-likelihood for classification) at each epoch.
+likelihood for classification) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions.
 \item \code{parameters}: A list of some tuning parameter values.
 \item \code{blueprint}: The \code{hardhat} blueprint data.

--- a/man/brulee_resnet.Rd
+++ b/man/brulee_resnet.Rd
@@ -234,10 +234,15 @@ A \code{brulee_resnet} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
 \item \code{loss}: A vector of loss values (MSE for regression, negative log-
-likelihood for classification) at each epoch.
+likelihood for classification) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions.
 \item \code{y_stats}: A list of summary statistics for numeric outcomes.
 \item \code{parameters}: A list of some tuning parameter values.

--- a/man/brulee_rln.Rd
+++ b/man/brulee_rln.Rd
@@ -190,9 +190,14 @@ and the predictor term(s) on the right-hand side.}
 A \code{brulee_rln} object with elements:
 \itemize{
 \item \code{model_obj}: a serialized raw vector for the torch module.
-\item \code{estimates}: a list of model parameter matrices per epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
-\item \code{loss}: a numeric vector of loss values (scaled MSE) at each epoch.
+\item \code{estimates}: a list of model parameter matrices per epoch. The first
+element is epoch zero (the randomly initialized parameters
+before training), so the list has \code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
+\item \code{loss}: a numeric vector of loss values (scaled MSE) at each epoch,
+starting with epoch zero.
 \item \code{dims}: a list of data dimensions.
 \item \code{y_stats}: a list of mean and standard deviation for the outcome.
 \item \code{parameters}: a list of tuning parameter values.

--- a/man/brulee_saint.Rd
+++ b/man/brulee_saint.Rd
@@ -292,10 +292,15 @@ A \code{brulee_saint} object with elements:
 \itemize{
 \item \code{models_obj}: a serialized raw vector for the torch module.
 \item \code{estimates}: a list of matrices with the model parameter estimates per
-epoch.
-\item \code{best_epoch}: an integer for the epoch with the smallest loss.
+epoch. The first element is epoch zero (the randomly
+initialized parameters before training), so the list has
+\code{epochs + 1} elements.
+\item \code{best_epoch}: an integer for the epoch with the smallest loss. Since
+\code{estimates} and \code{loss} include epoch zero, this epoch's
+values are at position \code{best_epoch + 1} in those objects.
 \item \code{loss}: A vector of loss values (MSE for regression, negative log-
-likelihood for classification) at each epoch.
+likelihood for classification) at each epoch, starting with
+epoch zero.
 \item \code{dim}: A list of data dimensions and feature metadata.
 \item \code{y_stats}: A list of summary statistics for numeric outcomes.
 \item \code{parameters}: A list of some tuning parameter values.

--- a/tests/testthat/_snaps/mlp-binary.md
+++ b/tests/testthat/_snaps/mlp-binary.md
@@ -1,0 +1,4 @@
+# mlp gradient clipping prevents loss overflow
+
+    Early stopping occurred at epoch 1 due to numerical overflow of the loss function.
+

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,13 @@
+# Keep the TabICL attach hook (R/aaa.R) from downloading weights over the network
+# during the package's own tests and R CMD check. End users still get the
+# automatic download; the package's checks opt out.
+options(brulee.tabicl_autodownload = FALSE)
+
+# Pin torch to a single intra-op thread for the whole suite. libtorch only honors
+# this before any parallel work has started, so it must happen here (in setup,
+# before the first tensor op) rather than inside individual tests. Single-threaded
+# reductions are deterministic within a platform, which the gradient-clipping
+# overflow tests (test-autoint.R / test-saint.R) rely on to behave consistently.
+if (rlang::is_installed("torch")) {
+  try(torch::torch_set_num_threads(1), silent = TRUE)
+}

--- a/tests/testthat/test-autoint.R
+++ b/tests/testthat/test-autoint.R
@@ -478,6 +478,7 @@ test_that("autoint gradient clipping prevents loss overflow", {
   )
   expect_true(any(is.nan(no_clip$loss)))
 
+  skip_on_os("mac")
   # With the default clipping, training completes without overflow
   set.seed(386)
   torch::torch_manual_seed(386)

--- a/tests/testthat/test-linear_reg-fit.R
+++ b/tests/testthat/test-linear_reg-fit.R
@@ -188,7 +188,10 @@ test_that("linear_reg includes epoch zero and coef() returns the best epoch", {
 
   # `coef()` returns the minimum-loss epoch's parameters, matching `predict()`.
   best <- fit$estimates[[which.min(fit$loss)]]
-  expect_equal(unname(coef(fit)), unname(c(best$fc1.bias, best$fc1.weight[1, ])))
+  expect_equal(
+    unname(coef(fit)),
+    unname(c(best$fc1.bias, best$fc1.weight[1, ]))
+  )
 
   # `epoch = 0` is now valid and returns the initial (pre-training) parameters.
   init <- fit$estimates[[1]]

--- a/tests/testthat/test-linear_reg-fit.R
+++ b/tests/testthat/test-linear_reg-fit.R
@@ -159,3 +159,73 @@ test_that("basic Linear regression sgd", {
 
   expect_true(lin_brier_sgd$.estimate < shuffled$.estimate)
 })
+
+test_that("linear_reg includes epoch zero and coef() returns the best epoch", {
+  skip_on_cran()
+  skip_if_not(torch::torch_is_installed())
+
+  set.seed(1)
+  n <- 150
+  df <- data.frame(x1 = rnorm(n), x2 = rnorm(n))
+  df$y <- df$x1 - 2 * df$x2 + rnorm(n)
+
+  set.seed(1)
+  torch::torch_manual_seed(1)
+  fit <- brulee_linear_reg(
+    y ~ .,
+    data = df,
+    epochs = 10L,
+    learn_rate = 0.05,
+    stop_iter = 100L,
+    verbose = FALSE,
+    device = "cpu"
+  )
+
+  # `loss` and `estimates` include epoch zero (the initial parameters), so they
+  # have one more element than the number of training epochs.
+  expect_length(fit$loss, 10L + 1L)
+  expect_length(fit$estimates, 10L + 1L)
+
+  # `coef()` returns the minimum-loss epoch's parameters, matching `predict()`.
+  best <- fit$estimates[[which.min(fit$loss)]]
+  expect_equal(unname(coef(fit)), unname(c(best$fc1.bias, best$fc1.weight[1, ])))
+
+  # `epoch = 0` is now valid and returns the initial (pre-training) parameters.
+  init <- fit$estimates[[1]]
+  expect_equal(
+    unname(coef(fit, epoch = 0)),
+    unname(c(init$fc1.bias, init$fc1.weight[1, ]))
+  )
+})
+
+test_that("print() reports the best epoch's loss (epoch-zero offset)", {
+  skip_on_cran()
+  skip_if_not(torch::torch_is_installed())
+
+  set.seed(1)
+  n <- 150
+  df <- data.frame(x1 = rnorm(n), x2 = rnorm(n))
+  df$y <- df$x1 - 2 * df$x2 + rnorm(n)
+
+  # Strictly decreasing loss, so the best epoch's loss differs from the one
+  # before it; this catches the off-by-one in the printed value.
+  set.seed(1)
+  torch::torch_manual_seed(1)
+  fit <- brulee_linear_reg(
+    y ~ .,
+    data = df,
+    epochs = 8L,
+    learn_rate = 0.005,
+    stop_iter = 100L,
+    validation = 0,
+    verbose = FALSE,
+    device = "cpu"
+  )
+
+  out <- capture.output(capture.output(print(fit), type = "message"))
+  loss_line <- grep("loss after", out, value = TRUE)
+  expect_length(loss_line, 1L)
+
+  best_loss <- signif(fit$loss[fit$best_epoch + 1L], 3)
+  expect_match(loss_line, paste0(": ", best_loss), fixed = TRUE)
+})

--- a/tests/testthat/test-mlp-binary.R
+++ b/tests/testthat/test-mlp-binary.R
@@ -297,3 +297,45 @@ test_that('linear activations', {
     )
   expect_s3_class(nn_log_biv, "brulee_mlp")
 })
+
+test_that("mlp gradient clipping prevents loss overflow", {
+  skip_on_cran()
+  skip_if_not_installed("torch")
+
+  set.seed(386)
+  n <- 200
+  df <- data.frame(x1 = rnorm(n), x2 = rnorm(n), x3 = rnorm(n))
+  df$class <- factor(ifelse(df$x1 - df$x2 + rnorm(n) > 0, "a", "b"))
+
+  mlp_args <- list(
+    class ~ .,
+    data = df,
+    hidden_units = 64L,
+    learn_rate = 100,
+    momentum = 0.9,
+    optimizer = "SGD",
+    batch_size = 16L,
+    epochs = 10L,
+    stop_iter = 100L,
+    validation = 0,
+    device = "cpu",
+    verbose = FALSE
+  )
+
+  # Without clipping, the aggressive learning rate overflows the loss
+  set.seed(386)
+  torch::torch_manual_seed(386)
+  expect_snapshot_warning(
+    no_clip <- do.call(
+      brulee_mlp,
+      c(mlp_args, grad_value_clip = Inf, grad_norm_clip = Inf)
+    )
+  )
+  expect_true(any(is.nan(no_clip$loss)))
+
+  # With the default clipping, training completes without overflow
+  set.seed(386)
+  torch::torch_manual_seed(386)
+  clipped <- do.call(brulee_mlp, mlp_args)
+  expect_false(any(is.nan(clipped$loss)))
+})

--- a/tests/testthat/test-mlp-regression.R
+++ b/tests/testthat/test-mlp-regression.R
@@ -610,3 +610,42 @@ test_that("summary.brulee_mlp shows output dim for multinomial fits", {
   expect_true(any(grepl("output dim: 3", out)))
   expect_false(any(grepl("Softmax", out)))
 })
+
+test_that("coef() returns the best (minimum-loss) epoch's parameters", {
+  skip_on_cran()
+  skip_if_not_installed("torch")
+
+  # Neural-network models prepend the initial parameters to `estimates`, so the
+  # iteration number is offset by one from the list index. `coef()` must apply
+  # the same offset as `predict()` so it returns the best epoch's parameters and
+  # not the one before it.
+  set.seed(1)
+  n <- 150
+  df <- data.frame(x1 = rnorm(n), x2 = rnorm(n))
+  df$y <- df$x1 - 2 * df$x2 + rnorm(n)
+
+  # A small learning rate gives a strictly decreasing loss, so the minimum is a
+  # single unique iteration (no plateau to mask an off-by-one).
+  set.seed(1)
+  torch::torch_manual_seed(1)
+  fit <- brulee_mlp(
+    y ~ .,
+    data = df,
+    hidden_units = 5L,
+    learn_rate = 0.005,
+    epochs = 8L,
+    stop_iter = 100L,
+    validation = 0,
+    verbose = FALSE,
+    device = "cpu"
+  )
+
+  expect_true(all(diff(fit$loss) < 0))
+
+  # `estimates[[i]]` is the model that produced `loss[i]`, so the default
+  # coefficients must come from the minimum-loss epoch.
+  expect_equal(coef(fit), fit$estimates[[which.min(fit$loss)]])
+
+  # `coef(epoch =)` must select the same parameters `predict(epoch =)` uses.
+  expect_equal(coef(fit, epoch = 3), fit$estimates[[3 + 1]])
+})


### PR DESCRIPTION
We have been getting inconsistent snapshots and results across run and operating systems. This PR repairs a variety of small issues that have contributed to this. 

- We lock down the computations to be deterministic by disallowing multiple threads during testing. 
- _Some_ models did not record the loss or parameters for the initialized network. This was a problem because, if overflow occurs on the first GD step, the best epoch as NA. We always add this result to the loss vector and the parameter array. 
  - That means a lot of functions needed to add 1L to their indexing, print and plot methods. 
  - Man file updates to describe this change. 