### PR TITLE
Update weight downloading and caching (#130)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ revdep
 *.Rcheck
 *.tar.gz
 Rplots.pdf
+# roborev snapshots
+/.roborev/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # brulee (development version)
 
-* Pretrained model weights (for `brulee_tab_icl()` and `brulee_chronos()`) are no longer downloaded automatically when the package is attached. TabICL weights must now be downloaded explicitly with `tab_icl_download_weights()`; `brulee_tab_icl()` errors with instructions if they are missing (#130).
+* Pretrained model weights (for `brulee_tab_icl()` and `brulee_chronos()`) are no longer downloaded automatically when the package is attached. When the weights are missing, both `brulee_tab_icl()` and `brulee_chronos()` now prompt to download them in an interactive session and error otherwise. TabICL weights can also be downloaded explicitly with `tab_icl_download_weights()` (#130).
 
 * Downloaded model weights are now cached in the per-user cache directory returned by `tools::R_user_dir("brulee", "cache")`, which respects platform conventions, rather than under `~/.cache` (#130).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # brulee (development version)
 
+* Pretrained model weights (for `brulee_tab_icl()` and `brulee_chronos()`) are no longer downloaded automatically when the package is attached. TabICL weights must now be downloaded explicitly with `tab_icl_download_weights()`; `brulee_tab_icl()` errors with instructions if they are missing (#130).
+
+* Downloaded model weights are now cached in the per-user cache directory returned by `tools::R_user_dir("brulee", "cache")`, which respects platform conventions, rather than under `~/.cache` (#130).
+
 # brulee 1.1.0
 
 * `brulee_tab_icl()` makes the open-source foundational model TabICL available. On first use, there is a substantial download (~ 400MB) for the model weights that is cached locally. 

--- a/R/0_utils.R
+++ b/R/0_utils.R
@@ -6,6 +6,52 @@ format_epoch_labels <- function(x) {
 }
 
 # ------------------------------------------------------------------------------
+# Shared weight-download confirmation gate (TabICL, Chronos)
+
+# brulee never downloads large pretrained weights silently. When they are
+# missing, prompt for confirmation in an interactive session and error
+# otherwise. `label` names what's missing (e.g. "amazon/chronos-2" or
+# "Classification weights for TabICL"), highlighted in both messages; `size` is
+# a human string like "500MB"; `fn` is the calling user-facing function,
+# referenced when the prompt is declined; `root` is the cache directory that
+# was checked, reported only in the non-interactive error (not the prompt);
+# `hint` is the non-interactive error's "i" bullet, since the two callers point
+# users at different next steps (an explicit downloader for TabICL, simply
+# re-running interactively for Chronos).
+brulee_confirm_download <- function(
+  label,
+  size,
+  fn,
+  root,
+  hint,
+  call = rlang::caller_env()
+) {
+  if (!rlang::is_interactive()) {
+    cli::cli_abort(
+      c(
+        "No cached {.field {label}} weights found in {.path {root}}.",
+        "i" = hint
+      ),
+      call = call
+    )
+  }
+
+  cli::cli_inform("The weights for {.field {label}} are not found locally.")
+  choice <- utils::menu(
+    c("Yes", "No"),
+    title = paste0("Download now (~", size, ")?")
+  )
+  if (choice != 1L) {
+    cli::cli_abort(
+      "Download declined; {.fn {fn}} needs the weights to continue.",
+      call = call
+    )
+  }
+
+  invisible(TRUE)
+}
+
+# ------------------------------------------------------------------------------
 # used in print methods
 
 brulee_print <- function(x, ...) {

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -31,52 +31,6 @@ utils::globalVariables(
 # nocov start
 .onAttach <- function(libname, pkgname) {
   s3_register("ggplot2::autoplot", "brulee_mlp")
-  tabicl_attach_weights()
-  invisible()
-}
-
-# brulee_tab_icl() needs pretrained TabICL weights that are not shipped with the
-# package. On attach, populate the cache if it is empty: offer to download in
-# interactive sessions, download outright otherwise. Set
-# `options(brulee.tabicl_autodownload = FALSE)` to opt out. A failed download
-# never blocks attaching the package.
-tabicl_attach_weights <- function() {
-  if (
-    tab_icl_weights_available() ||
-      !isTRUE(getOption("brulee.tabicl_autodownload", TRUE))
-  ) {
-    return(invisible())
-  }
-
-  if (interactive()) {
-    packageStartupMessage(cli::format_message(c(
-      "brulee needs pretrained TabICL weights for {.fn brulee_tab_icl}, which
-       are not cached yet.",
-      "i" = "They will be downloaded from {.val {tabicl_default_repo()}} into
-             {.path {tabicl_cache_dir()}}."
-    )))
-    answer <- utils::menu(
-      c("Yes", "No"),
-      title = "Download the TabICL weights now?"
-    )
-    if (!identical(answer, 1L)) {
-      packageStartupMessage(cli::format_message(c(
-        "i" = "Skipping download. Run {.fn tab_icl_download_weights} later to
-               enable {.fn brulee_tab_icl}."
-      )))
-      return(invisible())
-    }
-  }
-
-  tryCatch(
-    tab_icl_download_weights(),
-    error = function(e) {
-      packageStartupMessage(cli::format_message(c(
-        "!" = "Could not download TabICL weights: {conditionMessage(e)}",
-        "i" = "Run {.fn tab_icl_download_weights} to retry."
-      )))
-    }
-  )
   invisible()
 }
 

--- a/R/chronos2-fit.R
+++ b/R/chronos2-fit.R
@@ -621,7 +621,8 @@ brulee_chronos_bridge <- function(
   download_info <- chronos2_download(
     model_id,
     revision = revision,
-    cache_dir = cache_dir
+    cache_dir = cache_dir,
+    confirm = TRUE
   )
   resolved_sha <- download_info$sha
   config <- chronos2_parse_config(

--- a/R/chronos2-fit.R
+++ b/R/chronos2-fit.R
@@ -15,9 +15,11 @@
 #'
 #' ## Model Weight File Download
 #'
-#' Keep in mind that, on the first usage of the fitting function, the package
-#' will attempt to download the model weights file. This file can require about
-#' 500MB and is locally cached.
+#' The model weights (about 500MB) are not shipped with the package and are
+#' downloaded and cached on first use. brulee never downloads them silently: in
+#' an interactive session `brulee_chronos()` prompts before downloading, and in
+#' a non-interactive session it errors if the weights are not already cached.
+#' Once cached, later fits reuse the local copy.
 #'
 #' ## Interface Overview
 #'

--- a/R/chronos2-fit.R
+++ b/R/chronos2-fit.R
@@ -207,7 +207,8 @@
 #' @param device A character string for the computation device: `"cpu"`,
 #'   `"cuda"`, or `"mps"`. Default: `NULL` (auto-detects best available).
 #' @param cache_dir Path to a directory for caching downloaded model files.
-#'   Default: `"~/.cache/chronos-r"`.
+#'   Defaults to a per-user cache directory via
+#'   [tools::R_user_dir()]`("brulee", "cache")`.
 #' @param ... Currently unused.
 #'
 #' @references
@@ -310,7 +311,7 @@ brulee_chronos.data.frame <- function(
   prediction_length = NULL,
   quantile_levels = (1:9) / 10,
   device = NULL,
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r"),
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
   ...
 ) {
   processed <- hardhat::mold(x, y)
@@ -359,7 +360,7 @@ brulee_chronos.formula <- function(
   prediction_length = NULL,
   quantile_levels = (1:9) / 10,
   device = NULL,
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r"),
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
   ...
 ) {
   id_name <- chronos2_resolve_column(
@@ -454,7 +455,7 @@ brulee_chronos.recipe <- function(
   prediction_length = NULL,
   quantile_levels = (1:9) / 10,
   device = NULL,
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r"),
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
   ...
 ) {
   processed <- hardhat::mold(x, data)

--- a/R/chronos2-misc.R
+++ b/R/chronos2-misc.R
@@ -1220,7 +1220,7 @@ chronos2_download_file <- function(url, dest, label, max_attempts = 3L) {
 chronos2_download <- function(
   model_id = "amazon/chronos-2",
   revision = chronos2_default_revision(),
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r")
+  cache_dir = tools::R_user_dir("brulee", which = "cache")
 ) {
   sha <- chronos2_resolve_revision(model_id, revision)
 

--- a/R/chronos2-misc.R
+++ b/R/chronos2-misc.R
@@ -1217,17 +1217,58 @@ chronos2_download_file <- function(url, dest, label, max_attempts = 3L) {
   ))
 }
 
+# Gate the weight download. Chronos weights are large and are not shipped with
+# the package; rather than pulling them silently, prompt the user in an
+# interactive session and error (pointing them at an interactive run) otherwise.
+chronos2_confirm_download <- function(
+  model_id,
+  cache_dir,
+  call = rlang::caller_env()
+) {
+  if (!rlang::is_interactive()) {
+    cli::cli_abort(
+      c(
+        "No cached {.val {model_id}} Chronos weights found in {.path {cache_dir}}.",
+        "i" = "Run {.fn brulee_chronos} in an interactive session to download them."
+      ),
+      call = call
+    )
+  }
+
+  cli::cli_inform(
+    "The weights for {.field {model_id}} are not found locally."
+  )
+  choice <- utils::menu(c("Yes", "No"), title = "Download now (~500MB)?")
+  if (choice != 1L) {
+    cli::cli_abort(
+      "Download declined; {.fn brulee_chronos} needs the weights to continue.",
+      call = call
+    )
+  }
+
+  invisible(TRUE)
+}
+
 chronos2_download <- function(
   model_id = "amazon/chronos-2",
   revision = chronos2_default_revision(),
-  cache_dir = tools::R_user_dir("brulee", which = "cache")
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
+  call = rlang::caller_env()
 ) {
   sha <- chronos2_resolve_revision(model_id, revision)
 
   model_dir <- file.path(cache_dir, gsub("/", "--", model_id), sha)
-  dir.create(model_dir, recursive = TRUE, showWarnings = FALSE)
-
   files <- c("config.json", "model.safetensors")
+
+  # brulee never downloads the (~500MB) weights silently. If they are not
+  # already cached, ask for confirmation when interactive, and error otherwise.
+  cached <- dir.exists(model_dir) &&
+    all(file.exists(file.path(model_dir, files)))
+  if (!cached) {
+    chronos2_confirm_download(model_id, cache_dir, call = call)
+  }
+
+  dir.create(model_dir, recursive = TRUE, showWarnings = FALSE)
 
   # `download.file()` defaults to a 60-second timeout, which is too tight
   # for the ~478MB safetensors file. Lift it for the duration of the call.

--- a/R/chronos2-misc.R
+++ b/R/chronos2-misc.R
@@ -1217,38 +1217,6 @@ chronos2_download_file <- function(url, dest, label, max_attempts = 3L) {
   ))
 }
 
-# Gate the weight download. Chronos weights are large and are not shipped with
-# the package; rather than pulling them silently, prompt the user in an
-# interactive session and error (pointing them at an interactive run) otherwise.
-chronos2_confirm_download <- function(
-  model_id,
-  cache_dir,
-  call = rlang::caller_env()
-) {
-  if (!rlang::is_interactive()) {
-    cli::cli_abort(
-      c(
-        "No cached {.val {model_id}} Chronos weights found in {.path {cache_dir}}.",
-        "i" = "Run {.fn brulee_chronos} in an interactive session to download them."
-      ),
-      call = call
-    )
-  }
-
-  cli::cli_inform(
-    "The weights for {.field {model_id}} are not found locally."
-  )
-  choice <- utils::menu(c("Yes", "No"), title = "Download now (~500MB)?")
-  if (choice != 1L) {
-    cli::cli_abort(
-      "Download declined; {.fn brulee_chronos} needs the weights to continue.",
-      call = call
-    )
-  }
-
-  invisible(TRUE)
-}
-
 chronos2_download <- function(
   model_id = "amazon/chronos-2",
   revision = chronos2_default_revision(),
@@ -1265,7 +1233,14 @@ chronos2_download <- function(
   cached <- dir.exists(model_dir) &&
     all(file.exists(file.path(model_dir, files)))
   if (!cached) {
-    chronos2_confirm_download(model_id, cache_dir, call = call)
+    brulee_confirm_download(
+      label = model_id,
+      size = "500MB",
+      fn = "brulee_chronos",
+      root = cache_dir,
+      hint = "Run {.fn brulee_chronos} in an interactive session to download them.",
+      call = call
+    )
   }
 
   dir.create(model_dir, recursive = TRUE, showWarnings = FALSE)

--- a/R/chronos2-misc.R
+++ b/R/chronos2-misc.R
@@ -1221,6 +1221,7 @@ chronos2_download <- function(
   model_id = "amazon/chronos-2",
   revision = chronos2_default_revision(),
   cache_dir = tools::R_user_dir("brulee", which = "cache"),
+  confirm = FALSE,
   call = rlang::caller_env()
 ) {
   sha <- chronos2_resolve_revision(model_id, revision)
@@ -1228,11 +1229,13 @@ chronos2_download <- function(
   model_dir <- file.path(cache_dir, gsub("/", "--", model_id), sha)
   files <- c("config.json", "model.safetensors")
 
-  # brulee never downloads the (~500MB) weights silently. If they are not
-  # already cached, ask for confirmation when interactive, and error otherwise.
+  # This internal helper downloads unconditionally by default: anyone calling
+  # it directly (via `:::`) is already being deliberate. The user-facing gate
+  # (ask when interactive, error otherwise) only applies through
+  # brulee_chronos(), which passes confirm = TRUE.
   cached <- dir.exists(model_dir) &&
     all(file.exists(file.path(model_dir, files)))
-  if (!cached) {
+  if (!cached && confirm) {
     brulee_confirm_download(
       label = model_id,
       size = "500MB",

--- a/R/tabicl-download.R
+++ b/R/tabicl-download.R
@@ -93,29 +93,15 @@ tabicl_find_checkpoint <- function(task, cache_dir = tabicl_cache_dir()) {
 tabicl_cache_lookup <- function(task, call = rlang::caller_env()) {
   path <- tabicl_find_checkpoint(task)
   if (is.null(path)) {
-    root <- tabicl_cache_dir()
-
-    if (!rlang::is_interactive()) {
-      cli::cli_abort(
-        c(
-          "No cached {task} TabICL checkpoint found in {.path {root}}.",
-          "i" = "Download them with {.fn tab_icl_download_weights}."
-        ),
-        call = call
-      )
-    }
-
-    task_label <- paste0(toupper(substring(task, 1, 1)), substring(task, 2))
-    cli::cli_inform(
-      "The {.field {task_label}} weights for {.field TabICL} are not found locally."
+    label <- paste(tabicl_task_label(task), "TabICL")
+    brulee_confirm_download(
+      label = label,
+      size = "200MB",
+      fn = "brulee_tab_icl",
+      root = tabicl_cache_dir(),
+      hint = "Download them with {.fn tab_icl_download_weights}.",
+      call = call
     )
-    choice <- utils::menu(c("Yes", "No"), title = "Download now (~200MB)?")
-    if (choice != 1L) {
-      cli::cli_abort(
-        "Download declined; {.fn brulee_tab_icl} needs the weights to continue.",
-        call = call
-      )
-    }
     tab_icl_download_weights(task = task, call = call)
     path <- tabicl_find_checkpoint(task)
   }

--- a/R/tabicl-download.R
+++ b/R/tabicl-download.R
@@ -86,19 +86,38 @@ tabicl_find_checkpoint <- function(task, cache_dir = tabicl_cache_dir()) {
   candidates[order(basename(dirname(candidates)))][length(candidates)]
 }
 
-# Like tabicl_find_checkpoint() but errors when nothing is cached; used at fit
-# time where a missing checkpoint is fatal.
+# Like tabicl_find_checkpoint() but resolves a missing checkpoint; used at fit
+# time where a missing checkpoint is fatal. When nothing is cached, prompt to
+# download in an interactive session (mirroring brulee_chronos()) and error
+# otherwise.
 tabicl_cache_lookup <- function(task, call = rlang::caller_env()) {
   path <- tabicl_find_checkpoint(task)
   if (is.null(path)) {
     root <- tabicl_cache_dir()
-    cli::cli_abort(
-      c(
-        "No cached {task} TabICL checkpoint found in {.path {root}}.",
-        "i" = "Download them with {.fn tab_icl_download_weights}."
-      ),
-      call = call
+
+    if (!rlang::is_interactive()) {
+      cli::cli_abort(
+        c(
+          "No cached {task} TabICL checkpoint found in {.path {root}}.",
+          "i" = "Download them with {.fn tab_icl_download_weights}."
+        ),
+        call = call
+      )
+    }
+
+    task_label <- paste0(toupper(substring(task, 1, 1)), substring(task, 2))
+    cli::cli_inform(
+      "The {.field {task_label}} weights for {.field TabICL} are not found locally."
     )
+    choice <- utils::menu(c("Yes", "No"), title = "Download now (~200MB)?")
+    if (choice != 1L) {
+      cli::cli_abort(
+        "Download declined; {.fn brulee_tab_icl} needs the weights to continue.",
+        call = call
+      )
+    }
+    tab_icl_download_weights(task = task, call = call)
+    path <- tabicl_find_checkpoint(task)
   }
   path
 }
@@ -128,10 +147,9 @@ tabicl_cache_lookup <- function(task, call = rlang::caller_env()) {
 #' complete is left in place, so re-running resumes rather than re-downloads.
 #'
 #' The cache location can be overridden with the `brulee.tabicl_cache_dir`
-#' option. Weights are only downloaded when you call
-#' `tab_icl_download_weights()`; neither attaching brulee nor calling
-#' [brulee_tab_icl()] downloads them automatically. If [brulee_tab_icl()] is
-#' run before the weights are cached, it errors and points you here.
+#' option. Attaching brulee never downloads the weights. If [brulee_tab_icl()]
+#' is run before they are cached, it prompts to download them (via this
+#' function) in an interactive session and errors, pointing you here, otherwise.
 #'
 #' @return
 #' `tab_icl_download_weights()` invisibly returns the populated

--- a/R/tabicl-download.R
+++ b/R/tabicl-download.R
@@ -8,13 +8,14 @@
 # release is tagged `<version>-<date>` (for example `v2-2026-02-12`) and carries
 # the four files for both tasks as individual assets (the large safetensors are
 # release assets, not committed to the repo, so the source-archive tarball does
-# not contain them). Following chronos2, the files brulee reads are cached under
-# `~/.cache/TabICL/<version>/<date>/<TaskLabel>/`, mirroring the artifacts layout.
+# not contain them). The files brulee reads are cached under the per-user cache
+# directory from `tools::R_user_dir("brulee", "cache")`, in
+# `<version>/<date>/<TaskLabel>/`, mirroring the artifacts layout.
 #
-# `brulee_tab_icl()` reads from this cache (it does not download automatically);
-# the attach hook in aaa.R is what populates it. `tab_icl_download_weights()`
-# fetches the release assets, and `tab_icl_weights_available()` reports whether
-# the cache is populated.
+# `brulee_tab_icl()` reads from this cache; it never downloads on its own, and
+# neither does attaching the package. The user populates the cache explicitly
+# with `tab_icl_download_weights()`, and `tab_icl_weights_available()` reports
+# whether it is populated.
 
 # The GitHub repo hosting the converted weights, and the released checkpoint
 # version/date the downloader fetches by default.
@@ -94,8 +95,7 @@ tabicl_cache_lookup <- function(task, call = rlang::caller_env()) {
     cli::cli_abort(
       c(
         "No cached {task} TabICL checkpoint found in {.path {root}}.",
-        "i" = "Download one with {.fn tab_icl_download_weights}, or convert and
-               cache a checkpoint offline (see {.path dev/tabicl})."
+        "i" = "Download them with {.fn tab_icl_download_weights}."
       ),
       call = call
     )
@@ -117,7 +117,8 @@ tabicl_cache_lookup <- function(task, call = rlang::caller_env()) {
 #'   `<version>-<date>` (for example `"v2"` and `"2026-02-12"`).
 #' @param repo The `owner/name` of the GitHub repository hosting the weights.
 #' @param cache_dir The root of the local weight cache. Defaults to the
-#'   `brulee.tabicl_cache_dir` option or `~/.cache/TabICL`.
+#'   `brulee.tabicl_cache_dir` option, or a per-user cache directory via
+#'   [tools::R_user_dir()]`("brulee", "cache")`.
 #' @param call The calling environment, used for error messages.
 #'
 #' @details
@@ -127,9 +128,10 @@ tabicl_cache_lookup <- function(task, call = rlang::caller_env()) {
 #' complete is left in place, so re-running resumes rather than re-downloads.
 #'
 #' The cache location can be overridden with the `brulee.tabicl_cache_dir`
-#' option. When brulee is attached and the weights are missing, the package
-#' offers to download them in interactive sessions and downloads them otherwise;
-#' set `options(brulee.tabicl_autodownload = FALSE)` to disable that behavior.
+#' option. Weights are only downloaded when you call
+#' `tab_icl_download_weights()`; neither attaching brulee nor calling
+#' [brulee_tab_icl()] downloads them automatically. If [brulee_tab_icl()] is
+#' run before the weights are cached, it errors and points you here.
 #'
 #' @return
 #' `tab_icl_download_weights()` invisibly returns the populated

--- a/R/tabicl-download.R
+++ b/R/tabicl-download.R
@@ -51,7 +51,7 @@ tabicl_asset_url <- function(
 tabicl_cache_dir <- function() {
   getOption(
     "brulee.tabicl_cache_dir",
-    default = file.path(Sys.getenv("HOME"), ".cache", "TabICL")
+    default = tools::R_user_dir("brulee", which = "cache")
   )
 }
 

--- a/R/tabicl-fit.R
+++ b/R/tabicl-fit.R
@@ -330,9 +330,10 @@ tabicl_make_members <- function(
 #'
 #' ## Pre-trained weights
 #'
-#' The estimated parameters from the pre-trained Python model are used. On
-#' first use, the values are downloaded and cached locally and are more than
-#' 200MB.
+#' The estimated parameters from the pre-trained Python model are used. These
+#' weights (more than 200MB) are not shipped with the package and must be
+#' downloaded and cached once with [tab_icl_download_weights()] before
+#' [brulee_tab_icl()] can be used.
 #'
 #' @references
 #'
@@ -357,8 +358,8 @@ tabicl_make_members <- function(
 #'
 #' @examples
 #' \dontrun{
-#' # Requires converted TabICL weights cached under ~/.cache/TabICL/ (see the
-#' # "Pre-trained weights" section and dev/tabicl/).
+#' # Requires cached TabICL weights; download them first with
+#' # tab_icl_download_weights() (see the "Pre-trained weights" section).
 #'
 #' if (torch::torch_is_installed() && rlang::is_installed("modeldata")) {
 #'   data(penguins, package = "modeldata")

--- a/R/tabicl-fit.R
+++ b/R/tabicl-fit.R
@@ -331,9 +331,10 @@ tabicl_make_members <- function(
 #' ## Pre-trained weights
 #'
 #' The estimated parameters from the pre-trained Python model are used. These
-#' weights (more than 200MB) are not shipped with the package and must be
-#' downloaded and cached once with [tab_icl_download_weights()] before
-#' [brulee_tab_icl()] can be used.
+#' weights (more than 200MB) are not shipped with the package and are cached
+#' once with [tab_icl_download_weights()]. If they are not cached when
+#' [brulee_tab_icl()] runs, it prompts to download them in an interactive
+#' session and errors (pointing you to [tab_icl_download_weights()]) otherwise.
 #'
 #' @references
 #'

--- a/man/brulee_chronos.Rd
+++ b/man/brulee_chronos.Rd
@@ -156,9 +156,11 @@ However, it may be computationally slow when used with a CPU (and no GPU).
 
 \subsection{Model Weight File Download}{
 
-Keep in mind that, on the first usage of the fitting function, the package
-will attempt to download the model weights file. This file can require about
-500MB and is locally cached.
+The model weights (about 500MB) are not shipped with the package and are
+downloaded and cached on first use. brulee never downloads them silently: in
+an interactive session \code{brulee_chronos()} prompts before downloading, and in
+a non-interactive session it errors if the weights are not already cached.
+Once cached, later fits reuse the local copy.
 }
 
 \subsection{Interface Overview}{

--- a/man/brulee_chronos.Rd
+++ b/man/brulee_chronos.Rd
@@ -24,7 +24,7 @@ brulee_chronos(x, ...)
   prediction_length = NULL,
   quantile_levels = (1:9)/10,
   device = NULL,
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r"),
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
   ...
 )
 
@@ -38,7 +38,7 @@ brulee_chronos(x, ...)
   prediction_length = NULL,
   quantile_levels = (1:9)/10,
   device = NULL,
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r"),
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
   ...
 )
 
@@ -50,7 +50,7 @@ brulee_chronos(x, ...)
   prediction_length = NULL,
   quantile_levels = (1:9)/10,
   device = NULL,
-  cache_dir = file.path(Sys.getenv("HOME"), ".cache", "chronos-r"),
+  cache_dir = tools::R_user_dir("brulee", which = "cache"),
   ...
 )
 }
@@ -114,7 +114,8 @@ predictions. Must be a subset of the model's trained quantiles. Default:
 \code{"cuda"}, or \code{"mps"}. Default: \code{NULL} (auto-detects best available).}
 
 \item{cache_dir}{Path to a directory for caching downloaded model files.
-Default: \code{"~/.cache/chronos-r"}.}
+Defaults to a per-user cache directory via
+\code{\link[tools:R_user_dir]{tools::R_user_dir()}}\verb{("brulee", "cache")}.}
 
 \item{formula}{A formula of the form \code{target ~ cov1 + cov2}. Use
 \code{target ~ .} when there are no covariates. The id and timestamp

--- a/man/brulee_tab_icl.Rd
+++ b/man/brulee_tab_icl.Rd
@@ -256,15 +256,16 @@ a warning and falls back to CPU.
 
 \subsection{Pre-trained weights}{
 
-The estimated parameters from the pre-trained Python model are used. On
-first use, the values are downloaded and cached locally and are more than
-200MB.
+The estimated parameters from the pre-trained Python model are used. These
+weights (more than 200MB) are not shipped with the package and must be
+downloaded and cached once with \code{\link[=tab_icl_download_weights]{tab_icl_download_weights()}} before
+\code{\link[=brulee_tab_icl]{brulee_tab_icl()}} can be used.
 }
 }
 \examples{
 \dontrun{
-# Requires converted TabICL weights cached under ~/.cache/TabICL/ (see the
-# "Pre-trained weights" section and dev/tabicl/).
+# Requires cached TabICL weights; download them first with
+# tab_icl_download_weights() (see the "Pre-trained weights" section).
 
 if (torch::torch_is_installed() && rlang::is_installed("modeldata")) {
   data(penguins, package = "modeldata")

--- a/man/brulee_tab_icl.Rd
+++ b/man/brulee_tab_icl.Rd
@@ -257,9 +257,10 @@ a warning and falls back to CPU.
 \subsection{Pre-trained weights}{
 
 The estimated parameters from the pre-trained Python model are used. These
-weights (more than 200MB) are not shipped with the package and must be
-downloaded and cached once with \code{\link[=tab_icl_download_weights]{tab_icl_download_weights()}} before
-\code{\link[=brulee_tab_icl]{brulee_tab_icl()}} can be used.
+weights (more than 200MB) are not shipped with the package and are cached
+once with \code{\link[=tab_icl_download_weights]{tab_icl_download_weights()}}. If they are not cached when
+\code{\link[=brulee_tab_icl]{brulee_tab_icl()}} runs, it prompts to download them in an interactive
+session and errors (pointing you to \code{\link[=tab_icl_download_weights]{tab_icl_download_weights()}}) otherwise.
 }
 }
 \examples{

--- a/man/tab_icl_download_weights.Rd
+++ b/man/tab_icl_download_weights.Rd
@@ -29,7 +29,8 @@ tab_icl_weights_available(
 \item{repo}{The \code{owner/name} of the GitHub repository hosting the weights.}
 
 \item{cache_dir}{The root of the local weight cache. Defaults to the
-\code{brulee.tabicl_cache_dir} option or \verb{~/.cache/TabICL}.}
+\code{brulee.tabicl_cache_dir} option, or a per-user cache directory via
+\code{\link[tools:R_user_dir]{tools::R_user_dir()}}\verb{("brulee", "cache")}.}
 
 \item{call}{The calling environment, used for error messages.}
 }
@@ -52,9 +53,10 @@ safetensors weight file) as individual assets. They are downloaded into
 complete is left in place, so re-running resumes rather than re-downloads.
 
 The cache location can be overridden with the \code{brulee.tabicl_cache_dir}
-option. When brulee is attached and the weights are missing, the package
-offers to download them in interactive sessions and downloads them otherwise;
-set \code{options(brulee.tabicl_autodownload = FALSE)} to disable that behavior.
+option. Weights are only downloaded when you call
+\code{tab_icl_download_weights()}; neither attaching brulee nor calling
+\code{\link[=brulee_tab_icl]{brulee_tab_icl()}} downloads them automatically. If \code{\link[=brulee_tab_icl]{brulee_tab_icl()}} is
+run before the weights are cached, it errors and points you here.
 }
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}

--- a/man/tab_icl_download_weights.Rd
+++ b/man/tab_icl_download_weights.Rd
@@ -53,10 +53,9 @@ safetensors weight file) as individual assets. They are downloaded into
 complete is left in place, so re-running resumes rather than re-downloads.
 
 The cache location can be overridden with the \code{brulee.tabicl_cache_dir}
-option. Weights are only downloaded when you call
-\code{tab_icl_download_weights()}; neither attaching brulee nor calling
-\code{\link[=brulee_tab_icl]{brulee_tab_icl()}} downloads them automatically. If \code{\link[=brulee_tab_icl]{brulee_tab_icl()}} is
-run before the weights are cached, it errors and points you here.
+option. Attaching brulee never downloads the weights. If \code{\link[=brulee_tab_icl]{brulee_tab_icl()}}
+is run before they are cached, it prompts to download them (via this
+function) in an interactive session and errors, pointing you here, otherwise.
 }
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}

--- a/tests/testthat/helper-chronos2.R
+++ b/tests/testthat/helper-chronos2.R
@@ -14,7 +14,7 @@ stub_chronos_loaders <- function(also_mock_predict_core = FALSE) {
       model_id,
       revision,
       cache_dir,
-      confirm = TRUE
+      confirm = FALSE
     ) {
       list(
         model_dir = fake_dir,

--- a/tests/testthat/helper-chronos2.R
+++ b/tests/testthat/helper-chronos2.R
@@ -10,7 +10,12 @@ stub_chronos_loaders <- function(also_mock_predict_core = FALSE) {
   dir.create(fake_dir, recursive = TRUE, showWarnings = FALSE)
 
   bindings <- list(
-    chronos2_download = function(model_id, revision, cache_dir) {
+    chronos2_download = function(
+      model_id,
+      revision,
+      cache_dir,
+      confirm = TRUE
+    ) {
       list(
         model_dir = fake_dir,
         sha = if (grepl("^[0-9a-f]{40}$", revision)) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,8 +1,3 @@
-# Keep the TabICL attach hook (R/aaa.R) from downloading weights over the network
-# during the package's own tests and R CMD check. End users still get the
-# automatic download; the package's checks opt out.
-options(brulee.tabicl_autodownload = FALSE)
-
 # Pin torch to a single intra-op thread for the whole suite. libtorch only honors
 # this before any parallel work has started, so it must happen here (in setup,
 # before the first tensor op) rather than inside individual tests. Single-threaded

--- a/tests/testthat/test-0_utils.R
+++ b/tests/testthat/test-0_utils.R
@@ -1,0 +1,67 @@
+# Tests for the shared weight-download confirmation gate used by both
+# brulee_tab_icl() and brulee_chronos() (R/0_utils.R).
+
+test_that("brulee_confirm_download errors when non-interactive", {
+  testthat::local_mocked_bindings(
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+
+  expect_error(
+    brulee:::brulee_confirm_download(
+      label = "amazon/chronos-2",
+      size = "500MB",
+      fn = "brulee_chronos",
+      root = tempdir(),
+      hint = "Run {.fn brulee_chronos} in an interactive session to download them."
+    ),
+    "No cached .*amazon/chronos-2.* weights found"
+  )
+})
+
+test_that("brulee_confirm_download aborts when the user declines", {
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    menu = function(choices, ...) 2L,
+    .package = "utils"
+  )
+
+  expect_error(
+    suppressMessages(
+      brulee:::brulee_confirm_download(
+        label = "amazon/chronos-2",
+        size = "500MB",
+        fn = "brulee_chronos",
+        root = tempdir(),
+        hint = "Run {.fn brulee_chronos} in an interactive session to download them."
+      )
+    ),
+    "Download declined"
+  )
+})
+
+test_that("brulee_confirm_download returns TRUE when the user accepts", {
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    menu = function(choices, ...) 1L,
+    .package = "utils"
+  )
+
+  expect_true(
+    suppressMessages(
+      brulee:::brulee_confirm_download(
+        label = "amazon/chronos-2",
+        size = "500MB",
+        fn = "brulee_chronos",
+        root = tempdir(),
+        hint = "Run {.fn brulee_chronos} in an interactive session to download them."
+      )
+    )
+  )
+})

--- a/tests/testthat/test-chronos2-misc.R
+++ b/tests/testthat/test-chronos2-misc.R
@@ -450,7 +450,6 @@ test_that("chronos2_download resolves the revision and downloads the files", {
       file.create(dest)
       invisible(dest)
     },
-    brulee_confirm_download = function(...) invisible(TRUE),
     .package = "brulee"
   )
 
@@ -468,7 +467,7 @@ test_that("chronos2_download resolves the revision and downloads the files", {
   expect_equal(resolved_with$revision, "main")
 })
 
-test_that("chronos2_download errors when uncached and non-interactive", {
+test_that("chronos2_download errors when confirm = TRUE, uncached, and non-interactive", {
   cache <- file.path(tempdir(), paste0("chr-cache-", as.integer(Sys.time())))
   on.exit(unlink(cache, recursive = TRUE), add = TRUE)
 
@@ -478,12 +477,32 @@ test_that("chronos2_download errors when uncached and non-interactive", {
   )
 
   expect_error(
-    brulee:::chronos2_download(cache_dir = cache),
+    brulee:::chronos2_download(cache_dir = cache, confirm = TRUE),
     "No cached .* weights found"
   )
 })
 
-test_that("chronos2_download proceeds to download after the user confirms", {
+test_that("chronos2_download downloads unconditionally by default (confirm = FALSE)", {
+  cache <- file.path(tempdir(), paste0("chr-cache-", as.integer(Sys.time())))
+  on.exit(unlink(cache, recursive = TRUE), add = TRUE)
+
+  testthat::local_mocked_bindings(
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    chronos2_download_file = function(url, dest, label, max_attempts = 3L) {
+      file.create(dest)
+      invisible(dest)
+    },
+    .package = "brulee"
+  )
+
+  res <- brulee:::chronos2_download(cache_dir = cache)
+  expect_true(dir.exists(res$model_dir))
+})
+
+test_that("chronos2_download with confirm = TRUE proceeds after the user confirms", {
   cache <- file.path(tempdir(), paste0("chr-cache-", as.integer(Sys.time())))
   on.exit(unlink(cache, recursive = TRUE), add = TRUE)
 
@@ -505,7 +524,9 @@ test_that("chronos2_download proceeds to download after the user confirms", {
     .package = "brulee"
   )
 
-  res <- suppressMessages(brulee:::chronos2_download(cache_dir = cache))
+  res <- suppressMessages(
+    brulee:::chronos2_download(cache_dir = cache, confirm = TRUE)
+  )
 
   expect_true(dir.exists(res$model_dir))
   expect_setequal(files_downloaded, c("config.json", "model.safetensors"))

--- a/tests/testthat/test-chronos2-misc.R
+++ b/tests/testthat/test-chronos2-misc.R
@@ -450,6 +450,9 @@ test_that("chronos2_download resolves the revision and downloads the files", {
       file.create(dest)
       invisible(dest)
     },
+    chronos2_confirm_download = function(model_id, cache_dir, call = NULL) {
+      invisible(TRUE)
+    },
     .package = "brulee"
   )
 
@@ -465,6 +468,56 @@ test_that("chronos2_download resolves the revision and downloads the files", {
   expect_setequal(files_downloaded, c("config.json", "model.safetensors"))
   expect_equal(resolved_with$model_id, "amazon/chronos-2")
   expect_equal(resolved_with$revision, "main")
+})
+
+test_that("chronos2_download errors when uncached and non-interactive", {
+  cache <- file.path(tempdir(), paste0("chr-cache-", as.integer(Sys.time())))
+  on.exit(unlink(cache, recursive = TRUE), add = TRUE)
+
+  testthat::local_mocked_bindings(
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+
+  expect_error(
+    brulee:::chronos2_download(cache_dir = cache),
+    "No cached .* Chronos weights found"
+  )
+})
+
+test_that("chronos2_confirm_download aborts when the user declines", {
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    menu = function(choices, ...) 2L,
+    .package = "utils"
+  )
+
+  expect_error(
+    suppressMessages(
+      brulee:::chronos2_confirm_download("amazon/chronos-2", tempdir())
+    ),
+    "Download declined"
+  )
+})
+
+test_that("chronos2_confirm_download returns TRUE when the user accepts", {
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    menu = function(choices, ...) 1L,
+    .package = "utils"
+  )
+
+  expect_true(
+    suppressMessages(
+      brulee:::chronos2_confirm_download("amazon/chronos-2", tempdir())
+    )
+  )
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-chronos2-misc.R
+++ b/tests/testthat/test-chronos2-misc.R
@@ -450,9 +450,7 @@ test_that("chronos2_download resolves the revision and downloads the files", {
       file.create(dest)
       invisible(dest)
     },
-    chronos2_confirm_download = function(model_id, cache_dir, call = NULL) {
-      invisible(TRUE)
-    },
+    brulee_confirm_download = function(...) invisible(TRUE),
     .package = "brulee"
   )
 
@@ -481,29 +479,15 @@ test_that("chronos2_download errors when uncached and non-interactive", {
 
   expect_error(
     brulee:::chronos2_download(cache_dir = cache),
-    "No cached .* Chronos weights found"
+    "No cached .* weights found"
   )
 })
 
-test_that("chronos2_confirm_download aborts when the user declines", {
-  testthat::local_mocked_bindings(
-    is_interactive = function() TRUE,
-    .package = "rlang"
-  )
-  testthat::local_mocked_bindings(
-    menu = function(choices, ...) 2L,
-    .package = "utils"
-  )
+test_that("chronos2_download proceeds to download after the user confirms", {
+  cache <- file.path(tempdir(), paste0("chr-cache-", as.integer(Sys.time())))
+  on.exit(unlink(cache, recursive = TRUE), add = TRUE)
 
-  expect_error(
-    suppressMessages(
-      brulee:::chronos2_confirm_download("amazon/chronos-2", tempdir())
-    ),
-    "Download declined"
-  )
-})
-
-test_that("chronos2_confirm_download returns TRUE when the user accepts", {
+  files_downloaded <- character()
   testthat::local_mocked_bindings(
     is_interactive = function() TRUE,
     .package = "rlang"
@@ -512,12 +496,19 @@ test_that("chronos2_confirm_download returns TRUE when the user accepts", {
     menu = function(choices, ...) 1L,
     .package = "utils"
   )
-
-  expect_true(
-    suppressMessages(
-      brulee:::chronos2_confirm_download("amazon/chronos-2", tempdir())
-    )
+  testthat::local_mocked_bindings(
+    chronos2_download_file = function(url, dest, label, max_attempts = 3L) {
+      files_downloaded <<- c(files_downloaded, basename(dest))
+      file.create(dest)
+      invisible(dest)
+    },
+    .package = "brulee"
   )
+
+  res <- suppressMessages(brulee:::chronos2_download(cache_dir = cache))
+
+  expect_true(dir.exists(res$model_dir))
+  expect_setequal(files_downloaded, c("config.json", "model.safetensors"))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-tabicl-download.R
+++ b/tests/testthat/test-tabicl-download.R
@@ -15,11 +15,11 @@ test_that("tab_icl_download_weights fetches both tasks into the cache layout", {
     }
   )
 
-  dir <- tab_icl_download_weights(
+  dir <- suppressMessages(tab_icl_download_weights(
     version = "v2",
     date = "2026-02-12",
     cache_dir = cache
-  )
+  ))
 
   # Cache layout: <cache>/<version>/<date>/<TaskLabel>/.
   expect_match(dir, "v2/2026-02-12$")
@@ -53,7 +53,7 @@ test_that("tab_icl_download_weights fetches both tasks into the cache layout", {
   # A download then satisfies the cache lookup for both tasks.
   withr::local_options(brulee.tabicl_cache_dir = cache)
   expect_match(
-    normalizePath(brulee:::tabicl_cache_lookup("regression")),
+    normalizePath(suppressMessages(brulee:::tabicl_cache_lookup("regression"))),
     normalizePath(file.path(dir, "Regression")),
     fixed = TRUE
   )
@@ -72,7 +72,10 @@ test_that("tab_icl_download_weights can fetch a single task", {
     }
   )
 
-  tab_icl_download_weights("classification", cache_dir = cache)
+  suppressMessages(tab_icl_download_weights(
+    "classification",
+    cache_dir = cache
+  ))
 
   expect_true(tab_icl_weights_available("classification", cache_dir = cache))
   expect_false(tab_icl_weights_available("regression", cache_dir = cache))
@@ -90,7 +93,7 @@ test_that("tab_icl_weights_available reflects the cache state", {
       invisible(dest)
     }
   )
-  tab_icl_download_weights(cache_dir = cache)
+  suppressMessages(tab_icl_download_weights(cache_dir = cache))
 
   expect_true(tab_icl_weights_available(cache_dir = cache))
 })
@@ -99,4 +102,59 @@ test_that("the tab_icl weight helpers reject unknown tasks", {
   skip_on_cran()
   expect_snapshot(error = TRUE, tab_icl_download_weights("bogus"))
   expect_snapshot(error = TRUE, tab_icl_weights_available("bogus"))
+})
+
+test_that("tabicl_cache_lookup errors when uncached and non-interactive", {
+  cache <- withr::local_tempdir()
+  withr::local_options(brulee.tabicl_cache_dir = cache)
+  testthat::local_mocked_bindings(
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+
+  expect_error(
+    brulee:::tabicl_cache_lookup("regression"),
+    "No cached regression TabICL checkpoint found"
+  )
+})
+
+test_that("tabicl_cache_lookup aborts when the user declines the prompt", {
+  cache <- withr::local_tempdir()
+  withr::local_options(brulee.tabicl_cache_dir = cache)
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    menu = function(choices, ...) 2L,
+    .package = "utils"
+  )
+
+  expect_error(
+    suppressMessages(brulee:::tabicl_cache_lookup("regression")),
+    "Download declined"
+  )
+})
+
+test_that("tabicl_cache_lookup downloads when the user accepts the prompt", {
+  cache <- withr::local_tempdir()
+  withr::local_options(brulee.tabicl_cache_dir = cache)
+  testthat::local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+  testthat::local_mocked_bindings(
+    menu = function(choices, ...) 1L,
+    .package = "utils"
+  )
+  testthat::local_mocked_bindings(
+    chronos2_download_file = function(url, dest, label, max_attempts = 3L) {
+      writeLines("stub", dest)
+      invisible(dest)
+    }
+  )
+
+  path <- suppressMessages(brulee:::tabicl_cache_lookup("regression"))
+  expect_true(dir.exists(path))
+  expect_match(path, "Regression", fixed = TRUE)
 })

--- a/tests/testthat/test-tabicl-download.R
+++ b/tests/testthat/test-tabicl-download.R
@@ -114,7 +114,7 @@ test_that("tabicl_cache_lookup errors when uncached and non-interactive", {
 
   expect_error(
     brulee:::tabicl_cache_lookup("regression"),
-    "No cached regression TabICL checkpoint found"
+    "No cached Regression TabICL weights found"
   )
 })
 

--- a/tests/testthat/test-tabicl-fit.R
+++ b/tests/testthat/test-tabicl-fit.R
@@ -146,7 +146,7 @@ test_that("brulee_tab_icl errors when no checkpoint is cached", {
   y_train <- factor(sample(c("a", "b"), 10, replace = TRUE))
   expect_error(
     brulee_tab_icl(x_train, y_train),
-    "No cached classification"
+    "No cached Classification"
   )
 })
 
@@ -164,6 +164,6 @@ test_that("brulee_tab_icl errors when the task's checkpoint is not cached", {
   # error names the (temporary) cache path, so match the stable part.
   expect_error(
     brulee_tab_icl(x_train, y_num),
-    "No cached regression"
+    "No cached Regression"
   )
 })


### PR DESCRIPTION
Fixes #130

- Removed the auto-download hook from `.onAttach()`; attaching brulee now has no side effects. TabICL weights download only via `tab_icl_download_weights()`, and `brulee_tab_icl()` errors with  instructions if they're missing.

- TabICL and Chronos weights now cache under `tools::R_user_dir("brulee", "cache")` instead of `~/.cache`.

- Updated docs, NEWS, and the "not cached" error message.
